### PR TITLE
fix: new and active messages couldn't be distinguished

### DIFF
--- a/src/Sefirah.App/Data/Enums/MessageTypes.cs
+++ b/src/Sefirah.App/Data/Enums/MessageTypes.cs
@@ -47,6 +47,7 @@ public enum NotificationType
 public enum ConversationType
 {
     Active,
+    ActiveUpdated,
     Removed,
     New
 }

--- a/src/Sefirah.App/Services/SmsHandlerService.cs
+++ b/src/Sefirah.App/Services/SmsHandlerService.cs
@@ -43,6 +43,20 @@ public class SmsHandlerService(
                             Conversations.Insert(0, newConversation);
                         }
                         break;
+                    case ConversationType.ActiveUpdated:
+                        existingConversation = Conversations.FirstOrDefault(m => m.ThreadId == textConversation.ThreadId);
+                        if (existingConversation != null)
+                        {
+                            logger.Info("Updating existing conversation: {0}", existingConversation.ThreadId);
+                            existingConversation.NewMessageFromConversation(textConversation);
+                        }
+                        else
+                        {
+                            logger.Info("Active conversation not found, creating new: {0}", textConversation.ThreadId);
+                            var newConversation = new SmsConversation(textConversation);
+                            Conversations.Insert(0, newConversation);
+                        }
+                        break;
 
                     case ConversationType.Removed:
                         existingConversation = Conversations.FirstOrDefault(m => m.ThreadId == textConversation.ThreadId);


### PR DESCRIPTION
also update the local history of messages if the remote message was deleted when refreshing TODO: delete conversation messages without a refresh