### PR TITLE
feat: Make low battery alert threshold configurable

### DIFF
--- a/src/Sefirah/Constants.cs
+++ b/src/Sefirah/Constants.cs
@@ -1,9 +1,19 @@
 namespace Sefirah;
 public static class Constants
 {
+    public static class BatteryAlerts
+    {
+        public const int DefaultThreshold = 20;
+        public const int MinThreshold = 5;
+        public const int MaxThreshold = 50;
+    }
+
     public static class Notification
     {
         public const string FileTransferGroup = "file-transfer";
+        public const string BatteryGroup = "battery";
+
+        public static string GetBatteryTag(string deviceId) => $"battery_{deviceId}";
     }
 
     public static class ToastNotificationType

--- a/src/Sefirah/Data/Contracts/IBatteryAlertService.cs
+++ b/src/Sefirah/Data/Contracts/IBatteryAlertService.cs
@@ -1,0 +1,10 @@
+using Sefirah.Data.Models;
+
+namespace Sefirah.Data.Contracts;
+
+public interface IBatteryAlertService
+{
+    Task HandleBatteryStateAsync(PairedDevice device, BatteryState batteryState);
+
+    Task ReconcileBatteryAlertStateAsync(PairedDevice device);
+}

--- a/src/Sefirah/Data/Contracts/IDeviceSettingsService.cs
+++ b/src/Sefirah/Data/Contracts/IDeviceSettingsService.cs
@@ -40,6 +40,16 @@ public interface IDeviceSettingsService : IBaseSettingsService, INotifyPropertyC
     bool ShowNotificationToast { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to show low battery alerts for this device.
+    /// </summary>
+    bool LowBatteryAlertsEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the battery percentage threshold used for low battery alerts.
+    /// </summary>
+    int LowBatteryAlertThreshold { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to show badge for notifications on taskbar.
     /// </summary>
     bool ShowBadge { get; set; }

--- a/src/Sefirah/Data/Contracts/IPlatformNotificationHandler.cs
+++ b/src/Sefirah/Data/Contracts/IPlatformNotificationHandler.cs
@@ -32,6 +32,8 @@ public interface IPlatformNotificationHandler
 
     void ShowFileTransferNotification(string notificationTitle, string progressTitle, string status, string transferId, uint notificationSequence, double progress);
 
+    Task<bool> ShowBatteryNotification(string title, string text, string tag);
+
     Task ShowCallNotification(string title, string text, string tag, Enums.CallState callState, Uri? icon = null);
 
     /// <summary>

--- a/src/Sefirah/Helpers/AppLifecycleHelper.cs
+++ b/src/Sefirah/Helpers/AppLifecycleHelper.cs
@@ -137,6 +137,7 @@ public static class AppLifecycleHelper
                 .AddSingleton<INetworkService, NetworkService>()
 
                 .AddSingleton<INotificationService, NotificationService>()
+                .AddSingleton<IBatteryAlertService, BatteryAlertService>()
                 .AddSingleton<IClipboardService, ClipboardService>()
                 .AddSingleton<IRemoteMediaHandler, RemoteMediaHandler>()
                 .AddSingleton<SmsHandlerService>()

--- a/src/Sefirah/Platforms/Desktop/Services/DesktopNotificationHandler.cs
+++ b/src/Sefirah/Platforms/Desktop/Services/DesktopNotificationHandler.cs
@@ -175,6 +175,41 @@ public class DesktopNotificationHandler(
         }
     }
 
+    public async Task<bool> ShowBatteryNotification(string title, string text, string tag)
+    {
+        if (!await EnsureInitializedAsync() || _notifications is null)
+            return false;
+
+        try
+        {
+            var hints = new Dictionary<string, VariantValue>();
+            var categoryHint = NotificationHints.Category("battery");
+            var urgencyHint = NotificationHints.NormalUrgency();
+
+            hints.Add(categoryHint.Key, categoryHint.Value);
+            hints.Add(urgencyHint.Key, urgencyHint.Value);
+
+            var replacesId = _notificationIds.GetValueOrDefault(tag, 0u);
+            var notificationId = await _notifications.NotifyAsync(
+                appName: "Sefirah",
+                replacesId: replacesId,
+                appIcon: "battery-low",
+                summary: title,
+                body: text,
+                actions: [],
+                hints: hints,
+                expireTimeout: 8000);
+
+            _notificationIds[tag] = notificationId;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to show battery notification");
+            return false;
+        }
+    }
+
     public async void ShowClipboardNotification(string title, string text, string? actionLabel = null, string? actionData = null)
     {
         if (!await EnsureInitializedAsync() || _notifications is null) return;

--- a/src/Sefirah/Platforms/Windows/Services/WindowsNotificationHandler.cs
+++ b/src/Sefirah/Platforms/Windows/Services/WindowsNotificationHandler.cs
@@ -175,6 +175,30 @@ public class WindowsNotificationHandler(ILogger logger, ISessionManager sessionM
 
 
     /// <inheritdoc />
+    public Task<bool> ShowBatteryNotification(string title, string text, string tag)
+    {
+        try
+        {
+            var builder = new AppNotificationBuilder()
+                .AddText(title)
+                .AddText(text)
+                .SetTag(tag)
+                .SetGroup(Constants.Notification.BatteryGroup);
+
+            var notification = builder.BuildNotification();
+            notification.ExpiresOnReboot = true;
+            AppNotificationManager.Default.Show(notification);
+            return Task.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to show battery notification");
+            return Task.FromResult(false);
+        }
+    }
+
+
+    /// <inheritdoc />
     public Task ShowCallNotification(string title, string text, string tag, Data.Enums.CallState callState, Uri? icon = null)
     {
         try

--- a/src/Sefirah/Services/BatteryAlertService.cs
+++ b/src/Sefirah/Services/BatteryAlertService.cs
@@ -1,0 +1,122 @@
+using System.Collections.Concurrent;
+using CommunityToolkit.WinUI;
+using Sefirah.Data.Contracts;
+using Sefirah.Data.Models;
+using Sefirah.Extensions;
+
+namespace Sefirah.Services;
+
+public sealed class BatteryAlertService : IBatteryAlertService
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> deviceLocks = [];
+    private readonly ConcurrentDictionary<string, bool> shownAlerts = [];
+    private readonly IPlatformNotificationHandler platformNotificationHandler;
+    private readonly ILogger<BatteryAlertService> logger;
+
+    public BatteryAlertService(
+        ISessionManager sessionManager,
+        IPlatformNotificationHandler platformNotificationHandler,
+        ILogger<BatteryAlertService> logger)
+    {
+        this.platformNotificationHandler = platformNotificationHandler;
+        this.logger = logger;
+
+        sessionManager.ConnectionStatusChanged += OnConnectionStatusChanged;
+    }
+
+    public async Task HandleBatteryStateAsync(PairedDevice device, BatteryState batteryState)
+    {
+        await WithDeviceLockAsync(device.Id, async () =>
+        {
+            await App.MainWindow.DispatcherQueue.EnqueueAsync(() => device.BatteryStatus = batteryState);
+            await ReconcileBatteryAlertStateCoreAsync(device, batteryState);
+        });
+    }
+
+    public async Task ReconcileBatteryAlertStateAsync(PairedDevice device)
+    {
+        await WithDeviceLockAsync(device.Id, async () =>
+        {
+            await ReconcileBatteryAlertStateCoreAsync(device, device.BatteryStatus);
+        });
+    }
+
+    private SemaphoreSlim GetDeviceLock(string deviceId) =>
+        deviceLocks.GetOrAdd(deviceId, _ => new SemaphoreSlim(1, 1));
+
+    private async Task WithDeviceLockAsync(string deviceId, Func<Task> action)
+    {
+        var deviceLock = GetDeviceLock(deviceId);
+        await deviceLock.WaitAsync();
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            deviceLock.Release();
+        }
+    }
+
+    private async Task ReconcileBatteryAlertStateCoreAsync(PairedDevice device, BatteryState? batteryState)
+    {
+        var notificationTag = Constants.Notification.GetBatteryTag(device.Id);
+        if (!device.DeviceSettings.LowBatteryAlertsEnabled)
+        {
+            await ResetBatteryAlertStateCoreAsync(device.Id);
+            return;
+        }
+
+        if (batteryState is null)
+        {
+            return;
+        }
+
+        if (!ShouldShowLowBatteryAlert(batteryState, device.DeviceSettings.LowBatteryAlertThreshold))
+        {
+            await ResetBatteryAlertStateCoreAsync(device.Id);
+            return;
+        }
+
+        if (shownAlerts.ContainsKey(device.Id))
+        {
+            return;
+        }
+
+        var title = "BatteryNotification.Title".GetLocalizedResource();
+        var text = string.Format("BatteryNotification.Text".GetLocalizedResource(), device.Name, batteryState.BatteryLevel);
+
+        var shown = await platformNotificationHandler.ShowBatteryNotification(title, text, notificationTag);
+        if (!shown)
+        {
+            return;
+        }
+
+        shownAlerts[device.Id] = true;
+        logger.LogInformation(
+            "Displayed low battery notification for device {DeviceId} at {BatteryLevel}% with threshold {Threshold}%",
+            device.Id,
+            batteryState.BatteryLevel,
+            device.DeviceSettings.LowBatteryAlertThreshold);
+    }
+
+    private async void OnConnectionStatusChanged(object? sender, PairedDevice device)
+    {
+        if (device.IsConnected)
+        {
+            return;
+        }
+
+        await WithDeviceLockAsync(device.Id, () => ResetBatteryAlertStateCoreAsync(device.Id));
+    }
+
+    private async Task ResetBatteryAlertStateCoreAsync(string deviceId)
+    {
+        shownAlerts.TryRemove(deviceId, out _);
+        await platformNotificationHandler.RemoveNotificationByTag(Constants.Notification.GetBatteryTag(deviceId));
+    }
+
+    private static bool ShouldShowLowBatteryAlert(BatteryState batteryState, int threshold) =>
+        batteryState.BatteryLevel <= threshold && !batteryState.IsCharging;
+}

--- a/src/Sefirah/Services/MessageHandler.cs
+++ b/src/Sefirah/Services/MessageHandler.cs
@@ -8,6 +8,7 @@ public class MessageHandler(
     RemoteAppRepository remoteAppRepository,
     IDeviceManager deviceManager,
     INotificationService notificationService,
+    IBatteryAlertService batteryAlertService,
     IClipboardService clipboardService,
     SmsHandlerService smsHandlerService,
     IFileTransferService fileTransferService,
@@ -46,7 +47,7 @@ public class MessageHandler(
                     break;
 
                 case BatteryState batteryStatus:
-                    await App.MainWindow.DispatcherQueue.EnqueueAsync(() => device.BatteryStatus = batteryStatus);
+                    await batteryAlertService.HandleBatteryStateAsync(device, batteryStatus);
                     break;
 
                 case RingerModeState ringerMode:

--- a/src/Sefirah/Services/Settings/DeviceSettingsService.cs
+++ b/src/Sefirah/Services/Settings/DeviceSettingsService.cs
@@ -48,6 +48,24 @@ internal sealed partial class DeviceSettingsService(string deviceId, ISettingsSh
         set => Set(value);
     }
 
+    public bool LowBatteryAlertsEnabled
+    {
+        get => Get(true);
+        set => Set(value);
+    }
+
+    public int LowBatteryAlertThreshold
+    {
+        get => Math.Clamp(
+            Get(Constants.BatteryAlerts.DefaultThreshold),
+            Constants.BatteryAlerts.MinThreshold,
+            Constants.BatteryAlerts.MaxThreshold);
+        set => Set(Math.Clamp(
+            value,
+            Constants.BatteryAlerts.MinThreshold,
+            Constants.BatteryAlerts.MaxThreshold));
+    }
+
     public bool ShowBadge
     {
         get => Get(true);

--- a/src/Sefirah/Strings/en/Resources.resw
+++ b/src/Sefirah/Strings/en/Resources.resw
@@ -547,6 +547,18 @@ page.</value>
   <data name="ShowBadgeDescription" xml:space="preserve">
     <value>Show notification badge on taskbar</value>
   </data>
+  <data name="LowBatteryAlerts" xml:space="preserve">
+    <value>Low battery alerts</value>
+  </data>
+  <data name="LowBatteryAlertsDescription" xml:space="preserve">
+    <value>Show a notification when this device reaches or drops below the selected battery percentage</value>
+  </data>
+  <data name="LowBatteryThreshold" xml:space="preserve">
+    <value>Low battery threshold</value>
+  </data>
+  <data name="LowBatteryThresholdDescription" xml:space="preserve">
+    <value>Choose the battery percentage that triggers the alert for this device</value>
+  </data>
   <data name="IgnoreDuringDoNotDisturb" xml:space="preserve">
     <value>Ignore during Do Not Disturb</value>
   </data>
@@ -746,6 +758,12 @@ input text %pwd%</value>
   </data>
   <data name="ClipboardNotification.Title" xml:space="preserve">
     <value>Clipboard received</value>
+  </data>
+  <data name="BatteryNotification.Title" xml:space="preserve">
+    <value>Low battery</value>
+  </data>
+  <data name="BatteryNotification.Text" xml:space="preserve">
+    <value>{0} is at {1}% battery.</value>
   </data>
   <data name="OpenInBrowser" xml:space="preserve">
     <value>Open in browser</value>

--- a/src/Sefirah/ViewModels/Settings/DeviceSettingsViewModel.cs
+++ b/src/Sefirah/ViewModels/Settings/DeviceSettingsViewModel.cs
@@ -122,6 +122,50 @@ public sealed partial class DeviceSettingsViewModel : BaseViewModel
         }
     }
 
+    public bool LowBatteryAlertsEnabled
+    {
+        get => DeviceSettings.LowBatteryAlertsEnabled;
+        set
+        {
+            if (DeviceSettings.LowBatteryAlertsEnabled != value)
+            {
+                DeviceSettings.LowBatteryAlertsEnabled = value;
+                OnPropertyChanged();
+                _ = ReconcileBatteryAlertsAsync();
+            }
+        }
+    }
+
+    public int LowBatteryAlertThreshold
+    {
+        get => DeviceSettings.LowBatteryAlertThreshold;
+        set
+        {
+            var currentThreshold = DeviceSettings.LowBatteryAlertThreshold;
+            DeviceSettings.LowBatteryAlertThreshold = value;
+
+            if (DeviceSettings.LowBatteryAlertThreshold != currentThreshold)
+            {
+                OnPropertyChanged();
+                _ = ReconcileBatteryAlertsAsync();
+            }
+        }
+    }
+
+    public IReadOnlyList<int> LowBatteryAlertThresholdOptions { get; } =
+    [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+    ];
+
     public bool ShowBadge
     {
         get => DeviceSettings.ShowBadge;
@@ -639,6 +683,8 @@ public sealed partial class DeviceSettingsViewModel : BaseViewModel
 
     private readonly ISftpService sftpService = Ioc.Default.GetRequiredService<ISftpService>();
     private readonly IAdbService AdbService = Ioc.Default.GetRequiredService<IAdbService>();
+    private readonly IBatteryAlertService batteryAlertService = Ioc.Default.GetRequiredService<IBatteryAlertService>();
+    private readonly ILogger<DeviceSettingsViewModel> logger = Ioc.Default.GetRequiredService<ILogger<DeviceSettingsViewModel>>();
     private readonly IDeviceSettingsService DeviceSettings;
     public PairedDevice Device;
 
@@ -769,5 +815,17 @@ public sealed partial class DeviceSettingsViewModel : BaseViewModel
         var app = RemoteApps.First(p => p.PackageName == appPackage);
         app.DeviceInfo.Filter = filterKey;
         app.SelectedNotificationFilter = notificationFilter;
+    }
+
+    private async Task ReconcileBatteryAlertsAsync()
+    {
+        try
+        {
+            await batteryAlertService.ReconcileBatteryAlertStateAsync(Device);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to reconcile low battery alerts for device {DeviceId}", Device.Id);
+        }
     }
 }

--- a/src/Sefirah/Views/DeviceSettings/NotificationSettingsPage.xaml
+++ b/src/Sefirah/Views/DeviceSettings/NotificationSettingsPage.xaml
@@ -30,6 +30,35 @@
                     <ToggleSwitch IsOn="{x:Bind ViewModel.ShowNotificationToast, Mode=TwoWay}" />
                 </wuc:SettingsCard>
 
+                <wuc:SettingsCard Description="{helpers:ResourceString Name=LowBatteryAlertsDescription}" Header="{helpers:ResourceString Name=LowBatteryAlerts}">
+                    <wuc:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE850;" />
+                    </wuc:SettingsCard.HeaderIcon>
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.LowBatteryAlertsEnabled, Mode=TwoWay}" />
+                </wuc:SettingsCard>
+
+                <wuc:SettingsCard
+                    Description="{helpers:ResourceString Name=LowBatteryThresholdDescription}"
+                    Header="{helpers:ResourceString Name=LowBatteryThreshold}"
+                    IsEnabled="{x:Bind ViewModel.LowBatteryAlertsEnabled, Mode=OneWay}">
+                    <wuc:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE713;" />
+                    </wuc:SettingsCard.HeaderIcon>
+                    <ComboBox
+                        Width="120"
+                        ItemsSource="{x:Bind ViewModel.LowBatteryAlertThresholdOptions, Mode=OneWay}"
+                        SelectedItem="{x:Bind ViewModel.LowBatteryAlertThreshold, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="x:Int32">
+                                <TextBlock>
+                                    <Run Text="{x:Bind}" />
+                                    <Run Text="%" />
+                                </TextBlock>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </wuc:SettingsCard>
+
                 <wuc:SettingsCard Description="{helpers:ResourceString Name=ShowBadgeDescription}" Header="{helpers:ResourceString Name=ShowBadge}">
                     <wuc:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xF136;" />


### PR DESCRIPTION
This adds low battery alerts on the desktop side, with per-device settings for whether alerts are enabled and which battery threshold should trigger them.

**What changed:**

- added a battery alert service to track alert state and avoid repeated notifications while the battery stays below the threshold
- wired battery state handling through that service
- added per-device settings for low battery alerts and threshold
- added a notification settings UI for enabling alerts and selecting the threshold (ComboBox, increments of 5%, default of 20%, min=5%, max=50%)
- added platform notification handling for battery alerts on Windows and Desktop

**Translations:**

- alert text was added only to Strings/en/Resources.resw (I have translations staged and ready to go if need be)

**Manual verification:**

- enabled low battery alerts in device settings
- confirmed the threshold selector updates the stored value
- confirmed a low battery notification is shown when the device reports a low, non-charging battery
- confirmed the alert state resets when the battery rises above the threshold or the device disconnects