### PR TITLE
fix: correct inverted condition in RefreshDevicesAsync

### DIFF
--- a/src/Sefirah/Services/AdbService.cs
+++ b/src/Sefirah/Services/AdbService.cs
@@ -418,7 +418,7 @@ public class AdbService(
     private async Task RefreshDevicesAsync()
     {
         var devices = await adbClient.GetDevicesAsync();
-        if (devices.Any())
+        if (!devices.Any())
         {
             logger.Warn("No adb devices found");
             await App.MainWindow.DispatcherQueue.EnqueueAsync(() =>


### PR DESCRIPTION
The condition `if (devices.Any())` was inverted, causing the method to log "No adb devices found" and clear AdbDevices when devices WERE present, and skip that block when no devices were found. This meant connected ADB devices were never actually populated into AdbDevices.

Fix: Change to `if (!devices.Any())` so the early return only triggers when there are no devices.