### PR TITLE
feat: add battery service to report laptop battery status to connected devices 

### DIFF
--- a/src/Sefirah/Data/Contracts/IBatteryService.cs
+++ b/src/Sefirah/Data/Contracts/IBatteryService.cs
@@ -1,0 +1,10 @@
+using Sefirah.Data.Models;
+
+namespace Sefirah.Data.Contracts;
+
+public interface IBatteryService
+{
+    Task InitializeAsync();
+
+    void SendBatteryStatus(PairedDevice device);
+}

--- a/src/Sefirah/Helpers/AppLifecycleHelper.cs
+++ b/src/Sefirah/Helpers/AppLifecycleHelper.cs
@@ -43,6 +43,7 @@ public static class AppLifecycleHelper
         var generalSettingsService = Ioc.Default.GetRequiredService<IGeneralSettingsService>();
         var phoneLineService = Ioc.Default.GetRequiredService<IPhoneLineService>();
         var callManager = Ioc.Default.GetRequiredService<ICallManager>();
+        var batteryService = Ioc.Default.GetRequiredService<IBatteryService>();
 #if WINDOWS
         var windowsNotificationHandler = Ioc.Default.GetRequiredService<IPlatformNotificationHandler>();
         await windowsNotificationHandler.RegisterForNotifications();
@@ -55,6 +56,7 @@ public static class AppLifecycleHelper
             actionService.InitializeAsync(),
             notificationService.Initialize(),
             clipboardService.Initialize(),
+            batteryService.InitializeAsync(),
             callManager.Initialize()
         );
 

--- a/src/Sefirah/Platforms/Desktop/ServiceCollectionExtensions.cs
+++ b/src/Sefirah/Platforms/Desktop/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IPlatformNotificationHandler, DesktopNotificationHandler>();
         services.AddSingleton<IMediaService, DesktopMediaService>();
+        services.AddSingleton<IBatteryService, DesktopBatteryService>();
         services.AddSingleton<IActionService, DesktopActionService>();
         services.AddSingleton<IUpdateService, DesktopUpdateService>();
         services.AddSingleton<ISftpService, DesktopSftpService>();

--- a/src/Sefirah/Platforms/Desktop/Services/DesktopBatteryService.cs
+++ b/src/Sefirah/Platforms/Desktop/Services/DesktopBatteryService.cs
@@ -1,0 +1,16 @@
+using Sefirah.Data.Contracts;
+using Sefirah.Data.Models;
+
+namespace Sefirah.Platforms.Desktop.Services;
+
+public class DesktopBatteryService : IBatteryService
+{
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public void SendBatteryStatus(PairedDevice device)
+    {
+    }
+}

--- a/src/Sefirah/Platforms/Windows/ServiceCollectionExtensions.cs
+++ b/src/Sefirah/Platforms/Windows/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<IPlatformNotificationHandler, WindowsNotificationHandler>();
         services.AddSingleton<IMediaService, WindowsMediaService>();
+        services.AddSingleton<IBatteryService, WindowsBatteryService>();
         services.AddSingleton<IActionService, WindowsActionService>();
         services.AddSingleton<IUpdateService, WindowsUpdateService>();
         services.AddSingleton<IAppShortcutService, WindowsAppShortcutService>();

--- a/src/Sefirah/Platforms/Windows/Services/WindowsBatteryService.cs
+++ b/src/Sefirah/Platforms/Windows/Services/WindowsBatteryService.cs
@@ -8,14 +8,12 @@ public class WindowsBatteryService(
     ILogger logger,
     ISessionManager sessionManager) : IBatteryService
 {
-    private bool initialized;
     private BatteryState? lastBatteryState;
 
     public Task InitializeAsync()
     {
-        if (initialized) return Task.CompletedTask;
+        if (!IsBatteryPresent()) return Task.CompletedTask;
 
-        initialized = true;
         sessionManager.ConnectionStatusChanged += OnConnectionStatusChanged;
         Battery.AggregateBattery.ReportUpdated += OnBatteryReportUpdated;
         BroadcastBatteryStatus();
@@ -57,6 +55,11 @@ public class WindowsBatteryService(
         return lastBatteryState is null ||
                lastBatteryState.BatteryLevel != batteryState.BatteryLevel ||
                lastBatteryState.IsCharging != batteryState.IsCharging;
+    }
+
+    private static bool IsBatteryPresent()
+    {
+        return Battery.AggregateBattery.GetReport().Status is not BatteryStatus.NotPresent;
     }
 
     private BatteryState? GetBatteryState()

--- a/src/Sefirah/Platforms/Windows/Services/WindowsBatteryService.cs
+++ b/src/Sefirah/Platforms/Windows/Services/WindowsBatteryService.cs
@@ -1,0 +1,92 @@
+using Sefirah.Data.Models;
+using Windows.Devices.Power;
+using BatteryStatus = Windows.System.Power.BatteryStatus;
+
+namespace Sefirah.Platforms.Windows.Services;
+
+public class WindowsBatteryService(
+    ILogger logger,
+    ISessionManager sessionManager) : IBatteryService
+{
+    private bool initialized;
+    private BatteryState? lastBatteryState;
+
+    public Task InitializeAsync()
+    {
+        if (initialized) return Task.CompletedTask;
+
+        initialized = true;
+        sessionManager.ConnectionStatusChanged += OnConnectionStatusChanged;
+        Battery.AggregateBattery.ReportUpdated += OnBatteryReportUpdated;
+        BroadcastBatteryStatus();
+
+        return Task.CompletedTask;
+    }
+
+    public void SendBatteryStatus(PairedDevice device)
+    {
+        if (!device.IsConnected) return;
+
+        var batteryState = GetBatteryState();
+        if (batteryState is null) return;
+
+        device.SendMessage(batteryState);
+    }
+
+    private void OnConnectionStatusChanged(object? sender, PairedDevice device)
+    {
+        SendBatteryStatus(device);
+    }
+
+    private void OnBatteryReportUpdated(Battery sender, object args)
+    {
+        BroadcastBatteryStatus();
+    }
+
+    private void BroadcastBatteryStatus()
+    {
+        var batteryState = GetBatteryState();
+        if (batteryState is null || !HasBatteryStateChanged(batteryState)) return;
+
+        lastBatteryState = batteryState;
+        sessionManager.BroadcastMessage(batteryState);
+    }
+
+    private bool HasBatteryStateChanged(BatteryState batteryState)
+    {
+        return lastBatteryState is null ||
+               lastBatteryState.BatteryLevel != batteryState.BatteryLevel ||
+               lastBatteryState.IsCharging != batteryState.IsCharging;
+    }
+
+    private BatteryState? GetBatteryState()
+    {
+        try
+        {
+            var report = Battery.AggregateBattery.GetReport();
+            if (report.Status is BatteryStatus.NotPresent)
+            {
+                return null;
+            }
+
+            var remainingCapacity = report.RemainingCapacityInMilliwattHours;
+            var fullChargeCapacity = report.FullChargeCapacityInMilliwattHours;
+            if (!remainingCapacity.HasValue || !fullChargeCapacity.HasValue || fullChargeCapacity.Value <= 0)
+            {
+                return null;
+            }
+
+            var batteryLevel = (int)Math.Round(remainingCapacity.Value * 100d / fullChargeCapacity.Value);
+            return new BatteryState
+            {
+                BatteryLevel = Math.Clamp(batteryLevel, 0, 100),
+                IsCharging = report.Status is BatteryStatus.Charging
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.Error("Failed to read battery status", ex);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Adds a battery service that reads the host machine's battery status and broadcasts it to connected devices.

- `IBatteryService` — contract with `InitializeAsync` and `SendBatteryStatus`
- `WindowsBatteryService` — Windows implementation using `Windows.Devices.Power.Battery`; subscribes to
`ReportUpdated` for live updates and only broadcasts when the level or charging state changes
- `DesktopBatteryService` — no-op stub for the non-Windows desktop target


- Desktops without a battery are handled gracefully: `BatteryStatus.NotPresent` and null capacity values both result
in no message being sent
- Battery level is clamped to 0–100 to guard against out-of-range reports