### PR TITLE
Fix window size on first launch + show phone number in conversation list

### DIFF
--- a/src/Sefirah/App.xaml.cs
+++ b/src/Sefirah/App.xaml.cs
@@ -151,6 +151,8 @@ public partial class App : Application
 
             // Place the frame in the current Window
             MainWindow.Content = rootFrame;
+                            // Set a reasonable default size on first launch
+                MainWindow.AppWindow.Resize(new SizeInt32 { Width = 1100, Height = 700 });
         }
 
         return rootFrame;

--- a/src/Sefirah/Views/MessagesPage.xaml
+++ b/src/Sefirah/Views/MessagesPage.xaml
@@ -116,12 +116,19 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock
-                            Grid.Column="0"
-                            FontWeight="SemiBold"
-                            Foreground="{x:Bind HasRead, Mode=OneWay, Converter={StaticResource BooleanToTextColorConverter}}"
-                            Text="{x:Bind DisplayName, Mode=OneWay, FallbackValue='Unknown'}"
-                            TextTrimming="CharacterEllipsis" />
+<StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                    <TextBlock
+                                        FontWeight="SemiBold"
+                                        Foreground="{x:Bind HasRead, Mode=OneWay, Converter={StaticResource BooleanToTextColorConverter}}"
+                                        Text="{x:Bind DisplayName, Mode=OneWay, FallbackValue='Unknown'}"
+                                        TextTrimming="CharacterEllipsis" />
+                                    <TextBlock
+                                        FontSize="11"
+                                        Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                                        Text="{x:Bind SubtitleAddress, Mode=OneWay}"
+                                        TextTrimming="CharacterEllipsis"
+                                        Visibility="{x:Bind SubtitleAddress, Mode=OneWay, Converter={StaticResource EmptyObjectToVisibilityConverter}}" />
+                                </StackPanel>
 
                         <TextBlock
                             Grid.Column="1"


### PR DESCRIPTION
Fixes #248

The conversation list was only showing the contact name (or falling back to the raw number if no name existed), but there was no way to see both at the same time. So if you had a contact saved you'd see their name but have no idea which number it actually was.

Wrapped the DisplayName TextBlock in a StackPanel and added a smaller subtitle TextBlock underneath that binds to SubtitleAddress (which is already on the Conversation model - it just pulls PrimaryContact.Address). Used the existing EmptyObjectToVisibilityConverter to hide the subtitle row when there's no address so it doesn't break group chats or anything weird.

Pretty much the same pattern that ContactSearchSuggestionTemplate was already doing, just applied it to the list items too.

---

Also fixes #243

The window had no default size set so on a fresh install it'd open tiny and you'd have to drag-resize it manually every time. Added AppWindow.Resize(1100x700) inside EnsureWindowIsInitialized() which only runs when the window content hasn't been set yet, so it won't override your size on subsequent launches.