### PR TITLE
Fix macOS build issues

### DIFF
--- a/src/Sefirah/Platforms/Desktop/Program.cs
+++ b/src/Sefirah/Platforms/Desktop/Program.cs
@@ -90,6 +90,7 @@ internal class Program
                 .App(() => new App())
                 .UseX11()
                 .UseLinuxFrameBuffer()
+                .UseMacOS()
                 .Build();
 
             host.Run();

--- a/src/Sefirah/Sefirah.csproj
+++ b/src/Sefirah/Sefirah.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net10.0-windows10.0.26100;net10.0-desktop</TargetFrameworks>
 
@@ -63,7 +63,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <UnoIconForegroundFile>Assets\Icons\icon_foreground.svg</UnoIconForegroundFile>
+        <UnoIconForegroundFile>Assets/Icons/icon_foreground.svg</UnoIconForegroundFile>
         <UnoIconBackgroundColor Condition="'$(IsWinAppSdk)' == 'true'">Transparent</UnoIconBackgroundColor>
         <GenerateTestArtifacts>False</GenerateTestArtifacts>
         <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
@@ -83,10 +83,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <AdditionalFiles Include="Platforms\Desktop\Tray\DBusXml\com.canonical.dbusmenu.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Handler" />
-        <AdditionalFiles Include="Platforms\Desktop\Tray\DBusXml\com.castle.sefirah.SingleInstance.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Handler" />
-        <AdditionalFiles Include="Platforms\Desktop\Tray\DBusXml\org.kde.StatusNotifierItem.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Handler" />
-        <AdditionalFiles Include="Platforms\Desktop\Tray\DBusXml\org.kde.StatusNotifierWatcher.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Proxy" />
+        <AdditionalFiles Include="Platforms/Desktop/Tray/DBusXml/com.canonical.dbusmenu.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Handler" />
+        <AdditionalFiles Include="Platforms/Desktop/Tray/DBusXml/com.castle.sefirah.SingleInstance.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Handler" />
+        <AdditionalFiles Include="Platforms/Desktop/Tray/DBusXml/org.kde.StatusNotifierItem.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Handler" />
+        <AdditionalFiles Include="Platforms/Desktop/Tray/DBusXml/org.kde.StatusNotifierWatcher.xml" Namespace="Sefirah.Platforms.Desktop.Tray.DBus" DBusGeneratorMode="Proxy" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-windows10.0.26100'">
@@ -105,13 +105,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="Assets\Icons\IconResource.dll">
+        <Content Include="Assets/Icons/IconResource.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-        <Content Include="Assets\Icons\SefirahDark.ico">
+        <Content Include="Assets/Icons/SefirahDark.ico">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-        <Content Include="Assets\Icons\SefirahLight.ico">
+        <Content Include="Assets/Icons/SefirahLight.ico">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>
@@ -142,7 +142,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <UnoSplashScreen Update="Assets\Splash\splash_screen.svg">
+        <UnoSplashScreen Update="Assets/Splash/splash_screen.svg">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </UnoSplashScreen>
     </ItemGroup>

--- a/src/Sefirah/Services/MessageHandler.cs
+++ b/src/Sefirah/Services/MessageHandler.cs
@@ -87,7 +87,7 @@ public class MessageHandler(
                     break;
 
                 case SftpServerInfo sftpServerInfo:
-                    await sftpFeature.InitializeAsync(device, sftpServerInfo);
+                    await sftpFeature.Mount(device, sftpServerInfo);
                     break;
 
                 case FileTransferInfo fileTransfer:


### PR DESCRIPTION
## Description
Fixes #77 

This PR introduces a few minor fixes to allow the project to build and run successfully on macOS under the `net10.
  0-desktop` target. With these changes, the app compiles without errors and behaves on macOS just as it does on Linux.

### Changes made:
* **Fixed path separators in `Sefirah.csproj`**: Changed backslashes (`\`) to forward slashes (`/`) in `UnoIconForegroundFile`, `UnoSplashScreen`, `AdditionalFiles`, and `Content`. This ensures MSBuild can correctly
  resolve paths on Unix-based systems like macOS, while remaining fully compatible with Windows.
* **Fixed method call in `MessageHandler.cs`**: Updated an erroneous call from `sftpFeature.InitializeAsync(...)`
  to `sftpFeature.Mount(...)`, which correctly matches the `ISftpFeature` interface definition.
* **Enabled macOS backend in `Program.cs`**: Added `.UseMacOS()` to the `UnoPlatformHostBuilder` for the Desktop
  platform. Without this, the app attempts to use X11/FrameBuffer on macOS and crashes on startup.


Built and tested locally on a Macbook Pro m5 and the application compiles successfully, launches the native UI,
  starts local servers, and handles device discovery and syncing over the network smoothly.