### PR TITLE
fix: skip socket messages with an unknown type discriminator

### DIFF
--- a/src/Sefirah/Services/NetworkService.cs
+++ b/src/Sefirah/Services/NetworkService.cs
@@ -180,7 +180,20 @@ public class NetworkService(
 
             logger.Debug($"Processing message: {(messageString.Length > 100 ? string.Concat(messageString.AsSpan(0, 100), "...") : messageString)}");
 
-            var socketMessage = JsonMessageSerializer.DeserializeMessage(messageString);
+            SocketMessage? socketMessage;
+            try
+            {
+                socketMessage = JsonMessageSerializer.DeserializeMessage(messageString);
+            }
+            catch (JsonException ex)
+            {
+                // A peer running a different version can send message types this build does not know.
+                // Skipping the single message keeps the rest of the batch usable, whereas letting the
+                // exception escape discards every message parsed so far along with the remaining ones.
+                logger.Warn($"Skipping unrecognized message: {ex.Message}");
+                continue;
+            }
+
             if (socketMessage is not null)
             {
                 messages.Add(socketMessage);


### PR DESCRIPTION
One unrecognised message currently takes down every message around it.

`GetMessagesFromBuffer` pulls newline-delimited messages out of the receive buffer and deserialises each one. `JsonSerializer.Deserialize<SocketMessage>` throws on a type discriminator this build does not declare, and the exception escapes the loop: the already-parsed messages in `messages` are discarded along with everything still in the batch.

That is easy to hit whenever the two sides are not on the same version, which is normal for anyone running a release of one and a build of the other. In my case the phone was on the 3.0.1 release, which sends `ConnectionAck` right after authentication:

```
System.Text.Json.JsonException: Read unrecognized type discriminator id 'ConnectionAck'.
   at Sefirah.Services.NetworkService.GetMessagesFromBuffer(...)
   at Sefirah.Services.NetworkService.OnReceived(...)
```

The visible symptom was not an error but a silence: `SftpServerInfo` arrives in that same batch, so remote storage never mounted and no sync root appeared, while the session itself looked healthy.

The deserialisation is now wrapped per message. An unknown type is logged and skipped, and the rest of the batch survives:

```
[WRN] Skipping unrecognized message: Read unrecognized type discriminator id 'ConnectionAck'
```

Tested against a device one version behind: before the change remote storage never mounted, after it the warning appears once per connect and everything else works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
