### PR TITLE
feat: browse device files, photos and clipboard history from the desktop

### DIFF
--- a/src/Sefirah/Data/AppDatabase/DatabaseContext.cs
+++ b/src/Sefirah/Data/AppDatabase/DatabaseContext.cs
@@ -122,6 +122,7 @@ public class DatabaseContext
         db.CreateTable<AttachmentEntity>();
         db.CreateTable<CallLogEntity>();
         db.CreateTable<NotificationEntity>();
+        db.CreateTable<ClipboardEntity>();
     }
 
     public static void DropAllTables(SQLiteConnection db)

--- a/src/Sefirah/Data/AppDatabase/Models/ClipboardEntity.cs
+++ b/src/Sefirah/Data/AppDatabase/Models/ClipboardEntity.cs
@@ -1,0 +1,26 @@
+using SQLite;
+
+namespace Sefirah.Data.AppDatabase.Models;
+
+/// <summary>
+/// One thing the device put on its clipboard. Android keeps no history of its own, so this table
+/// is the only record of what was copied before the current item.
+/// </summary>
+public class ClipboardEntity
+{
+    [PrimaryKey, AutoIncrement]
+    public int Id { get; set; }
+
+    [Indexed]
+    public string DeviceId { get; set; } = string.Empty;
+
+    /// <summary>Mime type as the device reported it, or text/plain for plain text.</summary>
+    public string ClipboardType { get; set; } = string.Empty;
+
+    /// <summary>The text itself, or the path of the stored image.</summary>
+    public string Content { get; set; } = string.Empty;
+
+    public bool IsImage { get; set; }
+
+    public long TimestampMillis { get; set; }
+}

--- a/src/Sefirah/Data/AppDatabase/Repository/ClipboardRepository.cs
+++ b/src/Sefirah/Data/AppDatabase/Repository/ClipboardRepository.cs
@@ -1,0 +1,109 @@
+using Sefirah.Data.AppDatabase.Models;
+using Sefirah.Data.Models;
+using Sefirah.Utils;
+
+namespace Sefirah.Data.AppDatabase.Repository;
+
+public class ClipboardRepository(DatabaseContext context)
+{
+    /// <summary>
+    /// How much history to keep per device. Past this the oldest entries go, along with their images.
+    /// </summary>
+    private const int MaxEntries = 200;
+
+    public Task SaveAsync(string deviceId, string clipboardType, string content, bool isImage) =>
+        Task.Run(() =>
+        {
+            if (string.IsNullOrEmpty(content)) return;
+
+            // The device re-sends the current clipboard on every reconnect; no point stacking duplicates
+            var latest = context.Database.Table<ClipboardEntity>()
+                .Where(entry => entry.DeviceId == deviceId)
+                .OrderByDescending(entry => entry.TimestampMillis)
+                .FirstOrDefault();
+
+            if (latest is not null && latest.IsImage == isImage && latest.Content == content) return;
+
+            context.Database.Insert(new ClipboardEntity
+            {
+                DeviceId = deviceId,
+                ClipboardType = clipboardType,
+                Content = content,
+                IsImage = isImage,
+                TimestampMillis = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            });
+
+            Trim(deviceId);
+        });
+
+    public async Task<List<ClipboardEntry>> GetEntriesAsync(string deviceId)
+    {
+        var entities = await Task.Run(() =>
+            context.Database.Table<ClipboardEntity>()
+                .Where(entry => entry.DeviceId == deviceId)
+                .OrderByDescending(entry => entry.TimestampMillis)
+                .ToList());
+
+        return [.. entities.Select(ToEntry)];
+    }
+
+    public Task DeleteAsync(int id) =>
+        Task.Run(() =>
+        {
+            var entity = context.Database.Find<ClipboardEntity>(id);
+            if (entity is null) return;
+
+            DeleteImage(entity);
+            context.Database.Delete<ClipboardEntity>(id);
+        });
+
+    public Task ClearAsync(string deviceId) =>
+        Task.Run(() => DeleteAllForDevice(deviceId));
+
+    public void DeleteAllForDevice(string deviceId)
+    {
+        foreach (var entity in context.Database.Table<ClipboardEntity>().Where(entry => entry.DeviceId == deviceId).ToList())
+        {
+            DeleteImage(entity);
+        }
+        context.Database.Table<ClipboardEntity>().Delete(entry => entry.DeviceId == deviceId);
+    }
+
+    private void Trim(string deviceId)
+    {
+        var stale = context.Database.Table<ClipboardEntity>()
+            .Where(entry => entry.DeviceId == deviceId)
+            .OrderByDescending(entry => entry.TimestampMillis)
+            .Skip(MaxEntries)
+            .ToList();
+
+        foreach (var entity in stale)
+        {
+            DeleteImage(entity);
+            context.Database.Delete<ClipboardEntity>(entity.Id);
+        }
+    }
+
+    private static void DeleteImage(ClipboardEntity entity)
+    {
+        if (!entity.IsImage) return;
+
+        try
+        {
+            if (File.Exists(entity.Content)) File.Delete(entity.Content);
+        }
+        catch
+        {
+            // A leftover image is harmless, a crash while pruning is not
+        }
+    }
+
+    private static ClipboardEntry ToEntry(ClipboardEntity entity) => new()
+    {
+        Id = entity.Id,
+        ClipboardType = entity.ClipboardType,
+        Content = entity.Content,
+        IsImage = entity.IsImage,
+        Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(entity.TimestampMillis).LocalDateTime
+    };
+}

--- a/src/Sefirah/Data/Contracts/IClipboardFeature.cs
+++ b/src/Sefirah/Data/Contracts/IClipboardFeature.cs
@@ -5,6 +5,11 @@ namespace Sefirah.Data.Contracts;
 public interface IClipboardFeature : IFeature
 {
     /// <summary>
+    /// Raised once a new item from the device has been added to the history.
+    /// </summary>
+    event EventHandler<PairedDevice>? HistoryChanged;
+
+    /// <summary>
     /// Sets the clipboard from a remote
     /// </summary>
     Task SetContentAsync(ClipboardInfo clipboard, PairedDevice sourceDevice);

--- a/src/Sefirah/Data/Contracts/ISftpFeature.cs
+++ b/src/Sefirah/Data/Contracts/ISftpFeature.cs
@@ -19,6 +19,17 @@ public interface ISftpFeature : IFeature
     /// </summary>
     Task BrowseUriAsync(PairedDevice device);
 
+    /// <summary>
+    /// Raised when a device announces an SFTP endpoint. The device generates fresh credentials every
+    /// time its server restarts, so anything holding a connection has to rebuild it.
+    /// </summary>
+    event EventHandler<PairedDevice>? SessionChanged;
+
+    /// <summary>
+    /// Returns the SFTP endpoint the device is currently serving, or null when it has not announced one.
+    /// </summary>
+    SftpSession? GetSession(string deviceId);
+
     void Remove(string deviceId);
 
     Task RemoveAll();

--- a/src/Sefirah/Data/Models/ClipboardEntry.cs
+++ b/src/Sefirah/Data/Models/ClipboardEntry.cs
@@ -1,0 +1,50 @@
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// A past clipboard item from the device, as shown in the history.
+/// </summary>
+public sealed class ClipboardEntry
+{
+    public int Id { get; init; }
+
+    public required string ClipboardType { get; init; }
+
+    /// <summary>The text itself, or the path of the stored image.</summary>
+    public required string Content { get; init; }
+
+    public bool IsImage { get; init; }
+
+    public DateTime Timestamp { get; init; }
+
+    public bool IsText => !IsImage;
+
+    private ImageSource? thumbnail;
+
+    /// <summary>
+    /// Exposed as an ImageSource rather than a path: binding a string leaves WinUI to convert it,
+    /// and it refuses both an empty string and a null, taking the app down with it.
+    /// </summary>
+    public ImageSource? Thumbnail
+    {
+        get
+        {
+            if (thumbnail is not null) return thumbnail;
+            if (!IsImage || !File.Exists(Content)) return null;
+
+            var bitmap = new BitmapImage { DecodePixelWidth = 128 };
+            bitmap.UriSource = new Uri(Content);
+            thumbnail = bitmap;
+            return thumbnail;
+        }
+    }
+
+    /// <summary>Kept to a couple of lines: the list is for recognising an item, not reading it.</summary>
+    public string Preview => IsImage
+        ? Path.GetFileName(Content)
+        : Content.Length > 220 ? string.Concat(Content.AsSpan(0, 220), "…") : Content;
+
+    public string TimestampText => Timestamp.ToString("g");
+}

--- a/src/Sefirah/Data/Models/RemoteFileItem.cs
+++ b/src/Sefirah/Data/Models/RemoteFileItem.cs
@@ -1,0 +1,52 @@
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// An entry in the device filesystem, as listed over SFTP.
+/// </summary>
+public sealed class RemoteFileItem
+{
+    public required string Name { get; init; }
+
+    public required string FullPath { get; init; }
+
+    public bool IsDirectory { get; init; }
+
+    public bool IsFile => !IsDirectory;
+
+    public long Size { get; init; }
+
+    public DateTime LastModified { get; init; }
+
+    /// <summary>
+    /// Segoe Fluent Icons code point, the same icon family the rest of the app draws from.
+    /// </summary>
+    public string Glyph => ((char)(IsDirectory ? 0xE8B7 : GlyphFor(Path.GetExtension(Name)))).ToString();
+
+    public string SizeText => IsDirectory ? string.Empty : FormatSize(Size);
+
+    public string LastModifiedText => LastModified == default ? string.Empty : LastModified.ToString("g");
+
+    private static int GlyphFor(string extension) => extension.ToLowerInvariant() switch
+    {
+        ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" or ".webp" or ".heic" => 0xEB9F,
+        ".mp4" or ".mkv" or ".avi" or ".mov" or ".webm" or ".3gp" => 0xE714,
+        ".mp3" or ".wav" or ".flac" or ".ogg" or ".m4a" or ".opus" => 0xE189,
+        ".zip" or ".rar" or ".7z" or ".tar" or ".gz" => 0xF12B,
+        ".apk" => 0xECAA,
+        ".pdf" or ".txt" or ".md" or ".log" or ".json" or ".xml" or ".doc" or ".docx" => 0xE8A5,
+        _ => 0xE7C3
+    };
+
+    private static string FormatSize(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double size = bytes;
+        var unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+        return unit == 0 ? $"{bytes} {units[0]}" : $"{size:0.#} {units[unit]}";
+    }
+}

--- a/src/Sefirah/Data/Models/RemotePhotoItem.cs
+++ b/src/Sefirah/Data/Models/RemotePhotoItem.cs
@@ -1,0 +1,41 @@
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// An image on the device, shown in the gallery. The preview and the local copy fill in as they
+/// are fetched, which is why they are observable rather than set once.
+/// </summary>
+public sealed partial class RemotePhotoItem : ObservableObject
+{
+    public required string Name { get; init; }
+
+    public required string FullPath { get; init; }
+
+    public long Size { get; init; }
+
+    public DateTime LastModified { get; init; }
+
+    [ObservableProperty]
+    public partial BitmapImage? Preview { get; set; }
+
+    /// <summary>
+    /// Set once the full image has been pulled down and cached, so later actions skip the transfer.
+    /// </summary>
+    public string? LocalPath { get; set; }
+
+    public string Tooltip => $"{Name}{Environment.NewLine}{LastModified:g}   {FormatSize(Size)}";
+
+    private static string FormatSize(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB"];
+        double size = bytes;
+        var unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+        return unit == 0 ? $"{bytes} {units[0]}" : $"{size:0.#} {units[unit]}";
+    }
+}

--- a/src/Sefirah/Data/Models/SftpSession.cs
+++ b/src/Sefirah/Data/Models/SftpSession.cs
@@ -1,0 +1,12 @@
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// The SFTP endpoint a connected device is currently serving, as announced in <see cref="SftpServerInfo"/>.
+/// </summary>
+public sealed record SftpSession(
+    string Host,
+    int Port,
+    string Username,
+    string Password,
+    IReadOnlyList<string> Paths,
+    IReadOnlyList<string> PathNames);

--- a/src/Sefirah/Features/ClipboardFeature.cs
+++ b/src/Sefirah/Features/ClipboardFeature.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI;
+using Sefirah.Data.AppDatabase.Repository;
 using Sefirah.Data.Models;
 using Sefirah.Utils;
 using Windows.ApplicationModel.DataTransfer;
@@ -13,7 +14,8 @@ public class ClipboardFeature(
     ISessionManager sessionManager,
     IPlatformNotificationHandler platformNotificationHandler,
     IDeviceManager deviceManager,
-    IFileTransferService fileTransferService) : IClipboardFeature
+    IFileTransferService fileTransferService,
+    ClipboardRepository clipboardRepository) : IClipboardFeature
 {
     private readonly DispatcherQueue dispatcher = App.MainWindow.DispatcherQueue;
     private bool isMonitoring = false;
@@ -35,6 +37,8 @@ public class ClipboardFeature(
     };
     
     private bool isInternalUpdate; // To track if the clipboard change came from the remote device
+
+    public event EventHandler<PairedDevice>? HistoryChanged;
 
     public Task InitializeAsync()
     {
@@ -233,6 +237,8 @@ public class ClipboardFeature(
 
     public async Task SetContentAsync(object content, PairedDevice sourceDevice)
     {
+        await RecordHistoryAsync(content, sourceDevice);
+
         if (!sourceDevice.DeviceSettings.ClipboardReceive) return;
 
         await dispatcher.EnqueueAsync(async () =>
@@ -290,6 +296,39 @@ public class ClipboardFeature(
                 dispatcher.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () => isInternalUpdate = false);
             }
         });
+    }
+
+    /// <summary>
+    /// Keeps what the device copied. Android has no clipboard history to ask for, so unless an item
+    /// is recorded here as it arrives, the previous one is gone for good.
+    /// </summary>
+    private async Task RecordHistoryAsync(object content, PairedDevice sourceDevice)
+    {
+        try
+        {
+            switch (content)
+            {
+                case string text when !string.IsNullOrWhiteSpace(text):
+                    await clipboardRepository.SaveAsync(sourceDevice.Id, "text/plain", text, isImage: false);
+                    break;
+
+                case StorageFile file when SupportedImageFileTypes.ContainsKey(file.FileType.TrimStart('.').ToLowerInvariant()):
+                    // The incoming copy sits in the temporary folder, which is pruned after a day
+                    var kept = LocalAppPaths.CreateClipboardHistoryFilePath(file.FileType);
+                    File.Copy(file.Path, kept, overwrite: true);
+                    await clipboardRepository.SaveAsync(sourceDevice.Id, file.ContentType, kept, isImage: true);
+                    break;
+
+                default:
+                    return;
+            }
+
+            HistoryChanged?.Invoke(this, sourceDevice);
+        }
+        catch (Exception ex)
+        {
+            logger.Warn($"Failed to record clipboard history: {ex.Message}", ex);
+        }
     }
 
     private static async Task<StorageFile?> CreateClipboardImageFileAsync(string base64Content, string mimeType)

--- a/src/Sefirah/Helpers/AppLifecycleHelper.cs
+++ b/src/Sefirah/Helpers/AppLifecycleHelper.cs
@@ -113,6 +113,7 @@ public static class AppLifecycleHelper
                 .AddSingleton<SmsRepository>()
                 .AddSingleton<CallLogRepository>()
                 .AddSingleton<NotificationRepository>()
+                .AddSingleton<ClipboardRepository>()
 
                 // Platform-specific services
                 .AddPlatformServices()
@@ -143,6 +144,9 @@ public static class AppLifecycleHelper
                 .AddSingleton<MainPageViewModel>()
                 .AddSingleton<DevicesViewModel>()
                 .AddSingleton<AppsViewModel>()
+                .AddSingleton<FilesViewModel>()
+                .AddSingleton<PhotosViewModel>()
+                .AddSingleton<ClipboardViewModel>()
                 .AddSingleton<MessagesViewModel>()
                 .AddSingleton<CallsPageViewModel>()
                 )

--- a/src/Sefirah/Platforms/Desktop/Features/SftpFeature.cs
+++ b/src/Sefirah/Platforms/Desktop/Features/SftpFeature.cs
@@ -31,6 +31,7 @@ public class SftpFeature(
         logger.Info($"Mounting SFTP for {device.Name}, IP: {device.Address}, Port: {info.Port}, Username: {info.Username}");
 
         _sessions[device.Id] = new DeviceSession(device.Address, info);
+        SessionChanged?.Invoke(this, device);
 
         var preferSshfs = ShouldPreferSshfs();
         if (preferSshfs)
@@ -107,6 +108,13 @@ public class SftpFeature(
             logger.Error($"Failed to browse device {device.Name} via SFTP URI", ex);
         }
     }
+
+    public event EventHandler<PairedDevice>? SessionChanged;
+
+    public SftpSession? GetSession(string deviceId)
+        => _sessions.TryGetValue(deviceId, out var session)
+            ? new SftpSession(session.Host, session.Info.Port, session.Info.Username, session.Info.Password, session.Info.Paths, session.Info.PathNames)
+            : null;
 
     public Task RemoveAll()
     {

--- a/src/Sefirah/Platforms/Windows/Features/SftpFeature.cs
+++ b/src/Sefirah/Platforms/Windows/Features/SftpFeature.cs
@@ -52,6 +52,7 @@ public class SftpFeature(
         if (string.IsNullOrEmpty(device.Address)) return;
 
         _sessions[device.Id] = (device.Address, info);
+        SessionChanged?.Invoke(this, device);
 
         if (!device.DeviceSettings.StorageAccess) return;
         if (!StorageProviderSyncRootManager.IsSupported()) return;
@@ -170,6 +171,13 @@ public class SftpFeature(
             });
         }
     }
+
+    public event EventHandler<PairedDevice>? SessionChanged;
+
+    public SftpSession? GetSession(string deviceId)
+        => _sessions.TryGetValue(deviceId, out var session)
+            ? new SftpSession(session.Host, session.Info.Port, session.Info.Username, session.Info.Password, session.Info.Paths, session.Info.PathNames)
+            : null;
 
     public async Task RemoveAll()
     {

--- a/src/Sefirah/Strings/en-US/Resources.resw
+++ b/src/Sefirah/Strings/en-US/Resources.resw
@@ -388,6 +388,102 @@ page.</value>
   <data name="Apps" xml:space="preserve">
     <value>Apps</value>
   </data>
+<data name="Files" xml:space="preserve">
+    <value>Files</value>
+  </data>
+  <data name="Photos" xml:space="preserve">
+    <value>Photos</value>
+  </data>
+  <data name="ClipboardHistory" xml:space="preserve">
+    <value>Clipboard</value>
+  </data>
+  <data name="ClipboardHistorySubtitle" xml:space="preserve">
+    <value>What the device has copied since Sefirah started keeping track. Click an item to put it back on the Windows clipboard.</value>
+  </data>
+  <data name="ClipboardCopy" xml:space="preserve">
+    <value>Copy to clipboard</value>
+  </data>
+  <data name="ClipboardEmpty" xml:space="preserve">
+    <value>Nothing here yet. Copy something on the device and it shows up.</value>
+  </data>
+  <data name="ClipboardNoDevice" xml:space="preserve">
+    <value>Connect a device to see what it copies</value>
+  </data>
+  <data name="ClipboardImageMissing" xml:space="preserve">
+    <value>The stored image is gone</value>
+  </data>
+  <data name="ClipboardClearTitle" xml:space="preserve">
+    <value>Clear history</value>
+  </data>
+  <data name="ClipboardClearSubtitle" xml:space="preserve">
+    <value>Remove every stored clipboard item for this device? This cannot be undone.</value>
+  </data>
+  <data name="PhotosRecent" xml:space="preserve">
+    <value>Recent pictures on the device</value>
+  </data>
+  <data name="PhotosOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="PhotosCopy" xml:space="preserve">
+    <value>Copy to clipboard</value>
+  </data>
+  <data name="PhotosSave" xml:space="preserve">
+    <value>Save to PC</value>
+  </data>
+  <data name="PhotosEmpty" xml:space="preserve">
+    <value>No pictures found on the device</value>
+  </data>
+  <data name="PhotosUnavailable" xml:space="preserve">
+    <value>Connect a device and turn on Storage access for it in the Android app to see its pictures</value>
+  </data>
+  <data name="PhotosDisconnected" xml:space="preserve">
+    <value>Can't reach the device. Pictures come back on their own when it returns.</value>
+  </data>
+  <data name="PhotosDeleteTitle" xml:space="preserve">
+    <value>Delete picture</value>
+  </data>
+  <data name="PhotosDeleteSubtitle" xml:space="preserve">
+    <value>Delete '{0}' from the device? It goes to the device recycle bin.</value>
+  </data>
+  <data name="FilesOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="FilesDownload" xml:space="preserve">
+    <value>Save to PC</value>
+  </data>
+  <data name="FilesRename" xml:space="preserve">
+    <value>Rename</value>
+  </data>
+  <data name="FilesUpload" xml:space="preserve">
+    <value>Send a file to this folder</value>
+  </data>
+  <data name="FilesNewFolder" xml:space="preserve">
+    <value>New folder</value>
+  </data>
+  <data name="FilesRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="FilesGoUp" xml:space="preserve">
+    <value>Up one folder</value>
+  </data>
+  <data name="FilesCreate" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="FilesDisconnected" xml:space="preserve">
+    <value>Can't reach the device. It may have left the network; this page reconnects on its own when it comes back.</value>
+  </data>
+  <data name="FilesEmptyFolder" xml:space="preserve">
+    <value>This folder is empty</value>
+  </data>
+  <data name="FilesUnavailable" xml:space="preserve">
+    <value>Connect a device and turn on Storage access for it in the Android app to browse its files</value>
+  </data>
+  <data name="FilesDeleteTitle" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="FilesDeleteSubtitle" xml:space="preserve">
+    <value>Are you sure you want to delete '{0}' from the device? This action cannot be undone.</value>
+  </data>
   <data name="NewMessage" xml:space="preserve">
     <value>New message</value>
   </data>

--- a/src/Sefirah/Utils/DeviceSftpConnection.cs
+++ b/src/Sefirah/Utils/DeviceSftpConnection.cs
@@ -1,0 +1,117 @@
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using Renci.SshNet;
+using Renci.SshNet.Common;
+using Sefirah.Data.Models;
+
+namespace Sefirah.Utils;
+
+/// <summary>
+/// Owns an SFTP connection to the active device, rebuilding it whenever the device restarts its
+/// server. Each page keeps its own instance so their requests never interleave on one channel.
+/// </summary>
+public sealed class DeviceSftpConnection
+{
+    /// <summary>
+    /// A per-run key pair used only to authenticate against the device's own SFTP server.
+    /// </summary>
+    private static readonly Lazy<PrivateKeyFile> SessionKey = new(() =>
+    {
+        using var rsa = RSA.Create(2048);
+        using var pem = new MemoryStream(Encoding.ASCII.GetBytes(rsa.ExportPkcs8PrivateKeyPem()));
+        return new PrivateKeyFile(pem);
+    });
+
+    private readonly ILogger logger = Ioc.Default.GetRequiredService<ILogger>();
+    private readonly IDeviceManager deviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly ISftpFeature sftpFeature = Ioc.Default.GetRequiredService<ISftpFeature>();
+    private readonly object gate = new();
+
+    private SftpClient? client;
+
+    /// <summary>
+    /// Re-reads the endpoint every time: the device generates a fresh password whenever its
+    /// SFTP server restarts, so a cached one goes stale without warning.
+    /// </summary>
+    public SftpSession? CurrentSession()
+    {
+        var device = deviceManager.ActiveDevice;
+        return device is null ? null : sftpFeature.GetSession(device.Id);
+    }
+
+    /// <summary>
+    /// Runs an SFTP call off the UI thread, reconnecting once if the device dropped off the network
+    /// in the meantime, which it does every time it leaves Wi-Fi.
+    /// </summary>
+    public Task<T> RunAsync<T>(Func<SftpClient, T> operation) => Task.Run(() =>
+    {
+        // Only worth retrying a connection that was alive; retrying a fresh connect just doubles the wait
+        var hadConnection = client is not null;
+        try
+        {
+            return operation(Connect());
+        }
+        catch (Exception ex) when (hadConnection && ex is SshException or ObjectDisposedException or IOException or SocketException)
+        {
+            logger.Warn($"SFTP call failed, reconnecting once: {ex.Message}");
+            Drop();
+            return operation(Connect());
+        }
+    });
+
+    public void Drop()
+    {
+        lock (gate)
+        {
+            try
+            {
+                client?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.Warn($"Failed to close the SFTP connection: {ex.Message}", ex);
+            }
+            client = null;
+        }
+    }
+
+    /// <summary>
+    /// True when the failure means the device is off the network rather than the call being wrong.
+    /// A device that walks away gives no notification, the connection attempt simply times out.
+    /// </summary>
+    public static bool IsUnreachable(Exception ex)
+        => ex is SshOperationTimeoutException or SshConnectionException or SocketException or IOException;
+
+    private SftpClient Connect()
+    {
+        lock (gate)
+        {
+            if (client is { IsConnected: true }) return client;
+
+            var current = CurrentSession()
+                ?? throw new InvalidOperationException("The device has not announced an SFTP endpoint");
+
+            client?.Dispose();
+            logger.Info($"Connecting to SFTP {current.Host}:{current.Port} as {current.Username}");
+
+            // The announced password goes stale as soon as the device restarts its SFTP server, and the
+            // server accepts any public key, so keep a throwaway key as a fallback for that window.
+            var connectionInfo = new ConnectionInfo(current.Host, current.Port, current.Username,
+                new PasswordAuthenticationMethod(current.Username, current.Password),
+                new PrivateKeyAuthenticationMethod(current.Username, SessionKey.Value))
+            {
+                Timeout = TimeSpan.FromSeconds(10)
+            };
+
+            var sftp = new SftpClient(connectionInfo)
+            {
+                OperationTimeout = TimeSpan.FromSeconds(30),
+                KeepAliveInterval = TimeSpan.FromSeconds(15)
+            };
+            sftp.Connect();
+            client = sftp;
+            return sftp;
+        }
+    }
+}

--- a/src/Sefirah/Utils/ExifThumbnail.cs
+++ b/src/Sefirah/Utils/ExifThumbnail.cs
@@ -1,0 +1,123 @@
+using System.Buffers.Binary;
+
+namespace Sefirah.Utils;
+
+/// <summary>
+/// Pulls the small preview most cameras embed in a JPEG's EXIF block. Reading it costs a few
+/// kilobytes off the head of the file, against megabytes for the real image, which is the
+/// difference between a gallery that fills in at once and one that crawls over the network.
+/// </summary>
+public static class ExifThumbnail
+{
+    private const ushort JpegInterchangeFormat = 0x0201;
+    private const ushort JpegInterchangeFormatLength = 0x0202;
+
+    /// <summary>
+    /// Returns the embedded preview found in <paramref name="head"/>, the first bytes of a JPEG,
+    /// or null when the file carries none.
+    /// </summary>
+    public static byte[]? TryExtract(ReadOnlySpan<byte> head)
+    {
+        try
+        {
+            var app1 = FindExifApp1(head);
+            if (app1 < 0) return null;
+
+            // The TIFF header the EXIF offsets are relative to starts right after "Exif\0\0"
+            var tiff = app1 + 6;
+            if (tiff + 8 > head.Length) return null;
+
+            var little = head[tiff] == 0x49 && head[tiff + 1] == 0x49;
+            if (!little && !(head[tiff] == 0x4D && head[tiff + 1] == 0x4D)) return null;
+
+            var ifd0 = tiff + (int)ReadUInt32(head, tiff + 4, little);
+            var ifd1 = ReadNextIfdOffset(head, tiff, ifd0, little);
+            if (ifd1 <= 0) return null;
+
+            // IFD1 describes the thumbnail: where it starts and how long it is
+            var offset = 0;
+            var length = 0;
+            foreach (var (tag, value) in ReadEntries(head, tiff, tiff + ifd1, little))
+            {
+                if (tag == JpegInterchangeFormat) offset = (int)value;
+                else if (tag == JpegInterchangeFormatLength) length = (int)value;
+            }
+
+            if (offset <= 0 || length <= 0) return null;
+
+            var start = tiff + offset;
+            if (start < 0 || start + length > head.Length) return null;
+
+            return head.Slice(start, length).ToArray();
+        }
+        catch
+        {
+            // A malformed header is not worth reporting, the caller just falls back to the real image
+            return null;
+        }
+    }
+
+    private static int FindExifApp1(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 4 || data[0] != 0xFF || data[1] != 0xD8) return -1;
+
+        var position = 2;
+        while (position + 4 <= data.Length)
+        {
+            if (data[position] != 0xFF) return -1;
+
+            var marker = data[position + 1];
+            if (marker is 0xD8 or 0x01 || (marker >= 0xD0 && marker <= 0xD7))
+            {
+                position += 2;
+                continue;
+            }
+            if (marker == 0xDA) return -1; // start of scan, no metadata past here
+
+            var segmentLength = BinaryPrimitives.ReadUInt16BigEndian(data[(position + 2)..]);
+            if (marker == 0xE1 && position + 10 <= data.Length &&
+                data.Slice(position + 4, 4).SequenceEqual("Exif"u8))
+            {
+                return position + 4;
+            }
+
+            position += 2 + segmentLength;
+        }
+        return -1;
+    }
+
+    private static int ReadNextIfdOffset(ReadOnlySpan<byte> data, int tiff, int ifd, bool little)
+    {
+        if (ifd + 2 > data.Length) return 0;
+
+        var count = ReadUInt16(data, ifd, little);
+        var next = ifd + 2 + count * 12;
+        return next + 4 > data.Length ? 0 : (int)ReadUInt32(data, next, little);
+    }
+
+    private static List<(ushort Tag, uint Value)> ReadEntries(ReadOnlySpan<byte> data, int tiff, int ifd, bool little)
+    {
+        List<(ushort, uint)> entries = [];
+        if (ifd + 2 > data.Length) return entries;
+
+        var count = ReadUInt16(data, ifd, little);
+        for (var i = 0; i < count; i++)
+        {
+            var entry = ifd + 2 + i * 12;
+            if (entry + 12 > data.Length) break;
+
+            entries.Add((ReadUInt16(data, entry, little), ReadUInt32(data, entry + 8, little)));
+        }
+        return entries;
+    }
+
+    private static ushort ReadUInt16(ReadOnlySpan<byte> data, int offset, bool little)
+        => little
+            ? BinaryPrimitives.ReadUInt16LittleEndian(data[offset..])
+            : BinaryPrimitives.ReadUInt16BigEndian(data[offset..]);
+
+    private static uint ReadUInt32(ReadOnlySpan<byte> data, int offset, bool little)
+        => little
+            ? BinaryPrimitives.ReadUInt32LittleEndian(data[offset..])
+            : BinaryPrimitives.ReadUInt32BigEndian(data[offset..]);
+}

--- a/src/Sefirah/Utils/LocalAppPaths.cs
+++ b/src/Sefirah/Utils/LocalAppPaths.cs
@@ -6,6 +6,7 @@ public static class LocalAppPaths
     public const string DeviceSettingsFileName = "settings.json";
     public const string DeviceIconsFolderName = "Icons";
     public const string ClipboardFolderName = "Clipboard";
+    public const string ClipboardHistoryFolderName = "ClipboardHistory";
     public const string UserSettingsFileName = "user_settings.json";
 
     private static readonly TimeSpan TemporaryFileMaxAge = TimeSpan.FromHours(24);
@@ -38,6 +39,25 @@ public static class LocalAppPaths
             ? ".png"
             : extension[0] == '.' ? extension : $".{extension}";
         return Path.Combine(GetClipboardFolder(), $"clipboard_{Guid.NewGuid():N}{ext}");
+    }
+
+    /// <summary>
+    /// Clipboard images live in the temporary folder, which is pruned daily. History entries need to
+    /// outlive that, so their images are kept here instead.
+    /// </summary>
+    public static string GetClipboardHistoryFolder()
+    {
+        var path = Path.Combine(LocalFolder, ClipboardHistoryFolderName);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    public static string CreateClipboardHistoryFilePath(string? extension)
+    {
+        var ext = string.IsNullOrWhiteSpace(extension)
+            ? ".png"
+            : extension[0] == '.' ? extension : $".{extension}";
+        return Path.Combine(GetClipboardHistoryFolder(), $"clipboard_{Guid.NewGuid():N}{ext}");
     }
 
     public static void PruneTemporaryFolder()

--- a/src/Sefirah/ViewModels/ClipboardViewModel.cs
+++ b/src/Sefirah/ViewModels/ClipboardViewModel.cs
@@ -1,0 +1,188 @@
+using CommunityToolkit.WinUI;
+using Sefirah.Data.AppDatabase.Repository;
+using Sefirah.Data.Models;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+
+namespace Sefirah.ViewModels;
+
+/// <summary>
+/// The history of what the device has copied. Android keeps none of its own, so this is built here
+/// from the items the device sends as they happen.
+/// </summary>
+public sealed partial class ClipboardViewModel : BaseViewModel
+{
+    #region Services
+    private readonly IDeviceManager DeviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly IClipboardFeature ClipboardFeature = Ioc.Default.GetRequiredService<IClipboardFeature>();
+    private readonly ClipboardRepository Repository = Ioc.Default.GetRequiredService<ClipboardRepository>();
+    #endregion
+
+    private bool listening;
+    private string? boundDeviceId;
+
+    public ObservableCollection<ClipboardEntry> Entries { get; } = [];
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial string? StatusMessage { get; set; }
+
+    [ObservableProperty]
+    public partial ClipboardEntry? SelectedEntry { get; set; }
+
+    public bool HasStatus => !string.IsNullOrEmpty(StatusMessage);
+
+    partial void OnStatusMessageChanged(string? value) => OnPropertyChanged(nameof(HasStatus));
+
+    #region Lifetime
+
+    public async Task InitializeAsync()
+    {
+        if (!listening)
+        {
+            ClipboardFeature.HistoryChanged += OnHistoryChanged;
+            listening = true;
+        }
+
+        await LoadAsync();
+    }
+
+    public void Suspend()
+    {
+        if (!listening) return;
+
+        ClipboardFeature.HistoryChanged -= OnHistoryChanged;
+        listening = false;
+    }
+
+    private void OnHistoryChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+
+        dispatcher.TryEnqueue(async () => await LoadAsync());
+    }
+
+    private async Task LoadAsync()
+    {
+        var device = DeviceManager.ActiveDevice;
+        boundDeviceId = device?.Id;
+
+        if (device is null)
+        {
+            Entries.Clear();
+            StatusMessage = "ClipboardNoDevice".GetLocalizedResource();
+            return;
+        }
+
+        IsLoading = true;
+        try
+        {
+            var entries = await Repository.GetEntriesAsync(device.Id);
+
+            Entries.Clear();
+            foreach (var entry in entries)
+            {
+                Entries.Add(entry);
+            }
+
+            StatusMessage = Entries.Count == 0 ? "ClipboardEmpty".GetLocalizedResource() : null;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to load clipboard history: {ex.Message}", ex);
+            StatusMessage = ex.Message;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    #endregion
+
+    #region Commands
+
+    [RelayCommand]
+    private Task Refresh() => LoadAsync();
+
+    /// <summary>
+    /// Puts a past item back on the Windows clipboard, which is the whole point of keeping them.
+    /// </summary>
+    [RelayCommand]
+    private async Task Copy(ClipboardEntry? entry)
+    {
+        if (entry is null) return;
+
+        try
+        {
+            var package = new DataPackage { RequestedOperation = DataPackageOperation.Copy };
+
+            if (entry.IsImage)
+            {
+                if (!File.Exists(entry.Content))
+                {
+                    StatusMessage = "ClipboardImageMissing".GetLocalizedResource();
+                    return;
+                }
+
+                var file = await StorageFile.GetFileFromPathAsync(entry.Content);
+                package.Properties.PackageFamilyName = Package.Current.Id.FamilyName;
+                package.SetBitmap(RandomAccessStreamReference.CreateFromFile(file));
+                package.SetStorageItems([file], false);
+            }
+            else
+            {
+                package.SetText(entry.Content);
+            }
+
+            Clipboard.SetContent(package);
+            StatusMessage = null;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to copy history entry: {ex.Message}", ex);
+            StatusMessage = ex.Message;
+        }
+    }
+
+    [RelayCommand]
+    private async Task Delete(ClipboardEntry? entry)
+    {
+        if (entry is null) return;
+
+        await Repository.DeleteAsync(entry.Id);
+        Entries.Remove(entry);
+
+        if (Entries.Count == 0)
+        {
+            StatusMessage = "ClipboardEmpty".GetLocalizedResource();
+        }
+    }
+
+    [RelayCommand]
+    private async Task Clear()
+    {
+        if (boundDeviceId is null || Entries.Count == 0) return;
+
+        var dialog = new ContentDialog
+        {
+            Title = "ClipboardClearTitle".GetLocalizedResource(),
+            Content = "ClipboardClearSubtitle".GetLocalizedResource(),
+            PrimaryButtonText = "Remove".GetLocalizedResource(),
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        if (await dialog.ShowAsync() is not ContentDialogResult.Primary) return;
+
+        await Repository.ClearAsync(boundDeviceId);
+        Entries.Clear();
+        StatusMessage = "ClipboardEmpty".GetLocalizedResource();
+    }
+
+    #endregion
+}

--- a/src/Sefirah/ViewModels/FilesViewModel.cs
+++ b/src/Sefirah/ViewModels/FilesViewModel.cs
@@ -1,0 +1,478 @@
+using Renci.SshNet;
+using Sefirah.Data.Models;
+using Sefirah.Utils;
+
+namespace Sefirah.ViewModels;
+
+/// <summary>
+/// Browses the device filesystem over the SFTP endpoint the device announces while connected,
+/// independently of whether the platform managed to mount it locally.
+/// </summary>
+public sealed partial class FilesViewModel : BaseViewModel
+{
+    #region Services
+    private readonly IDeviceManager DeviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly ISftpFeature SftpFeature = Ioc.Default.GetRequiredService<ISftpFeature>();
+    private readonly ISessionManager SessionManager = Ioc.Default.GetRequiredService<ISessionManager>();
+    #endregion
+
+    // One navigation at a time: overlapping listings fight over the connection and over the bound collections
+    private readonly SemaphoreSlim navigationLock = new(1, 1);
+    private readonly DeviceSftpConnection connection = new();
+
+    private bool listening;
+    private string? boundDeviceId;
+    private string rootPath = "/";
+    private string currentPath = "/";
+
+    public ObservableCollection<RemoteFileItem> Items { get; } = [];
+
+    /// <summary>
+    /// Replaced wholesale rather than mutated: BreadcrumbBar does not survive its source being
+    /// cleared and refilled item by item.
+    /// </summary>
+    [ObservableProperty]
+    public partial IReadOnlyList<string> PathSegments { get; set; } = [];
+
+    [ObservableProperty]
+    public partial IReadOnlyList<string> Volumes { get; set; } = [];
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsBusy { get; set; }
+
+    [ObservableProperty]
+    public partial string? StatusMessage { get; set; }
+
+    [ObservableProperty]
+    public partial int SelectedVolumeIndex { get; set; }
+
+    public bool HasMultipleVolumes => Volumes.Count > 1;
+
+    public bool CanGoUp => currentPath.TrimEnd('/') != rootPath.TrimEnd('/');
+
+    public bool HasStatus => !string.IsNullOrEmpty(StatusMessage);
+
+    partial void OnStatusMessageChanged(string? value) => OnPropertyChanged(nameof(HasStatus));
+
+    partial void OnVolumesChanged(IReadOnlyList<string> value) => OnPropertyChanged(nameof(HasMultipleVolumes));
+
+    partial void OnSelectedVolumeIndexChanged(int value)
+    {
+        var paths = connection.CurrentSession()?.Paths;
+        if (paths is null || value < 0 || value >= paths.Count) return;
+
+        // The ComboBox echoes the volume back while its source is being set up; only act on a real change
+        if (paths[value].TrimEnd('/') == rootPath.TrimEnd('/')) return;
+
+        rootPath = paths[value];
+        _ = NavigateAsync(rootPath);
+    }
+
+    #region Lifetime
+
+    /// <summary>
+    /// Picks up the endpoint of the currently active device and lists its root.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        if (!listening)
+        {
+            SftpFeature.SessionChanged += OnSessionChanged;
+            SessionManager.ConnectionStatusChanged += OnConnectionStatusChanged;
+            listening = true;
+        }
+
+        await LoadRootAsync();
+    }
+
+    /// <summary>
+    /// Stops following the device and drops the connection, so it is not kept busy while the page is away.
+    /// </summary>
+    public void Suspend()
+    {
+        if (listening)
+        {
+            SftpFeature.SessionChanged -= OnSessionChanged;
+            SessionManager.ConnectionStatusChanged -= OnConnectionStatusChanged;
+            listening = false;
+        }
+
+        connection.Drop();
+    }
+
+    /// <summary>
+    /// The device announced a new endpoint, which means new credentials: rebuild and stay where the user was.
+    /// </summary>
+    private void OnSessionChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+
+        connection.Drop();
+        dispatcher.TryEnqueue(async () =>
+        {
+            var current = connection.CurrentSession();
+            if (current is null) return;
+
+            var paths = current.Paths.Count > 0 ? current.Paths : ["/"];
+            rootPath = paths[Math.Clamp(SelectedVolumeIndex, 0, paths.Count - 1)];
+
+            // Come back to the folder the user was looking at, falling back to the root if it is gone
+            var target = currentPath.StartsWith(rootPath, StringComparison.Ordinal) ? currentPath : rootPath;
+            await NavigateAsync(target);
+        });
+    }
+
+    private void OnConnectionStatusChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+        if (device.IsConnected) return;
+
+        connection.Drop();
+        dispatcher.TryEnqueue(() =>
+        {
+            Items.Clear();
+            StatusMessage = "FilesDisconnected".GetLocalizedResource();
+        });
+    }
+
+    private async Task LoadRootAsync()
+    {
+        boundDeviceId = DeviceManager.ActiveDevice?.Id;
+        var current = connection.CurrentSession();
+        Items.Clear();
+
+        if (current is null)
+        {
+            Volumes = [];
+            PathSegments = [];
+            StatusMessage = "FilesUnavailable".GetLocalizedResource();
+            return;
+        }
+
+        var paths = current.Paths.Count > 0 ? current.Paths : ["/"];
+
+        // Set the root before the index, so the change handler recognises the echo and stays quiet
+        rootPath = paths[0];
+        Volumes = [.. paths.Select((path, i) => current.PathNames.Count > i ? current.PathNames[i] : path)];
+        SelectedVolumeIndex = 0;
+
+        await NavigateAsync(rootPath);
+    }
+
+    #endregion
+
+    #region Navigation
+
+    [RelayCommand]
+    private Task Refresh() => NavigateAsync(currentPath);
+
+    [RelayCommand]
+    private Task GoUp()
+    {
+        if (!CanGoUp) return Task.CompletedTask;
+
+        var parent = currentPath.TrimEnd('/');
+        var separator = parent.LastIndexOf('/');
+        parent = separator <= 0 ? "/" : parent[..separator];
+        return NavigateAsync(parent);
+    }
+
+    /// <summary>
+    /// Navigates to the breadcrumb segment at <paramref name="index"/>, 0 being the volume root.
+    /// </summary>
+    public Task NavigateToSegmentAsync(int index)
+    {
+        if (index < 0 || index >= PathSegments.Count) return Task.CompletedTask;
+
+        var path = rootPath.TrimEnd('/');
+        for (var i = 1; i <= index; i++)
+        {
+            path += "/" + PathSegments[i];
+        }
+        return NavigateAsync(string.IsNullOrEmpty(path) ? "/" : path);
+    }
+
+    [RelayCommand]
+    private async Task Open(RemoteFileItem? item)
+    {
+        if (item is null) return;
+
+        if (item.IsDirectory)
+        {
+            await NavigateAsync(item.FullPath);
+            return;
+        }
+
+        await RunAsync(async () =>
+        {
+            // Files are streamed to a temp copy first, there is nothing to open in place over SFTP
+            var local = Path.Combine(Path.GetTempPath(), "Sefirah", item.Name);
+            Directory.CreateDirectory(Path.GetDirectoryName(local)!);
+
+            await connection.RunAsync(sftp =>
+            {
+                using var stream = File.Create(local);
+                sftp.DownloadFile(item.FullPath, stream);
+                return true;
+            });
+
+            Process.Start(new ProcessStartInfo(local) { UseShellExecute = true });
+        });
+    }
+
+    private async Task NavigateAsync(string path)
+    {
+        await navigationLock.WaitAsync();
+        try
+        {
+            IsLoading = true;
+            StatusMessage = null;
+
+            var entries = await connection.RunAsync(sftp => sftp
+                .ListDirectory(path)
+                .Where(entry => entry.Name is not "." and not "..")
+                .Select(entry => new RemoteFileItem
+                {
+                    Name = entry.Name,
+                    FullPath = entry.FullName,
+                    IsDirectory = entry.IsDirectory,
+                    Size = entry.IsDirectory ? 0 : entry.Length,
+                    LastModified = entry.LastWriteTime
+                })
+                .OrderByDescending(entry => entry.IsDirectory)
+                .ThenBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList());
+
+            currentPath = path;
+            Items.Clear();
+            foreach (var entry in entries)
+            {
+                Items.Add(entry);
+            }
+
+            PathSegments = BuildBreadcrumb();
+            if (Items.Count == 0)
+            {
+                StatusMessage = "FilesEmptyFolder".GetLocalizedResource();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to list {path}: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsLoading = false;
+            OnPropertyChanged(nameof(CanGoUp));
+            navigationLock.Release();
+        }
+    }
+
+    private IReadOnlyList<string> BuildBreadcrumb()
+    {
+        List<string> segments = [Volumes.Count > 0 ? Volumes[Math.Clamp(SelectedVolumeIndex, 0, Volumes.Count - 1)] : "/"];
+
+        var relative = currentPath.Length > rootPath.Length ? currentPath[rootPath.Length..] : string.Empty;
+        segments.AddRange(relative.Split('/', StringSplitOptions.RemoveEmptyEntries));
+        return segments;
+    }
+
+    #endregion
+
+    #region File operations
+
+    [RelayCommand]
+    private async Task Download(RemoteFileItem? item)
+    {
+        if (item is null || item.IsDirectory) return;
+
+        var folder = await PickerHelper.PickFolderAsync();
+        if (folder is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = Path.Combine(folder.Path, item.Name);
+            await connection.RunAsync(sftp =>
+            {
+                using var stream = File.Create(local);
+                sftp.DownloadFile(item.FullPath, stream);
+                return true;
+            });
+        });
+    }
+
+    [RelayCommand]
+    private async Task Upload()
+    {
+        var file = await PickerHelper.PickFileAsync();
+        if (file is null) return;
+
+        await RunAsync(async () =>
+        {
+            var target = CombinePath(currentPath, file.Name);
+            await connection.RunAsync(sftp =>
+            {
+                using var stream = File.OpenRead(file.Path);
+                sftp.UploadFile(stream, target);
+                return true;
+            });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    [RelayCommand]
+    private async Task NewFolder()
+    {
+        var name = await PromptForNameAsync(
+            "FilesNewFolder".GetLocalizedResource(),
+            "FilesCreate".GetLocalizedResource(),
+            string.Empty);
+        if (name is null) return;
+
+        await RunAsync(async () =>
+        {
+            var target = CombinePath(currentPath, name);
+            await connection.RunAsync(sftp => { sftp.CreateDirectory(target); return true; });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    [RelayCommand]
+    private async Task Rename(RemoteFileItem? item)
+    {
+        if (item is null) return;
+
+        var name = await PromptForNameAsync(
+            "FilesRename".GetLocalizedResource(),
+            "FilesRename".GetLocalizedResource(),
+            item.Name);
+        if (name is null || name == item.Name) return;
+
+        await RunAsync(async () =>
+        {
+            var target = CombinePath(currentPath, name);
+            await connection.RunAsync(sftp => { sftp.RenameFile(item.FullPath, target); return true; });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    [RelayCommand]
+    private async Task Delete(RemoteFileItem? item)
+    {
+        if (item is null) return;
+
+        var dialog = new ContentDialog
+        {
+            Title = "FilesDeleteTitle".GetLocalizedResource(),
+            Content = string.Format("FilesDeleteSubtitle".GetLocalizedResource(), item.Name),
+            PrimaryButtonText = "Remove".GetLocalizedResource(),
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        if (await dialog.ShowAsync() is not ContentDialogResult.Primary) return;
+
+        await RunAsync(async () =>
+        {
+            await connection.RunAsync(sftp =>
+            {
+                if (item.IsDirectory)
+                {
+                    DeleteRecursive(sftp, item.FullPath);
+                }
+                else
+                {
+                    sftp.DeleteFile(item.FullPath);
+                }
+                return true;
+            });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    private static void DeleteRecursive(SftpClient sftp, string path)
+    {
+        foreach (var entry in sftp.ListDirectory(path))
+        {
+            if (entry.Name is "." or "..") continue;
+
+            if (entry.IsDirectory)
+            {
+                DeleteRecursive(sftp, entry.FullName);
+            }
+            else
+            {
+                sftp.DeleteFile(entry.FullName);
+            }
+        }
+        sftp.DeleteDirectory(path);
+    }
+
+    #endregion
+
+    #region Plumbing
+
+    private static string Describe(Exception ex) => ex switch
+    {
+        InvalidOperationException => "FilesUnavailable".GetLocalizedResource(),
+        _ when DeviceSftpConnection.IsUnreachable(ex) => "FilesDisconnected".GetLocalizedResource(),
+        _ => ex.Message
+    };
+
+    private static string CombinePath(string directory, string name)
+        => directory.TrimEnd('/') + "/" + name;
+
+    /// <summary>
+    /// Runs an operation with the busy indicator on, turning any failure into a message instead of a crash.
+    /// </summary>
+    private async Task RunAsync(Func<Task> operation)
+    {
+        if (IsBusy) return;
+
+        IsBusy = true;
+        try
+        {
+            await operation();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"File operation failed: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static async Task<string?> PromptForNameAsync(string title, string primaryText, string initial)
+    {
+        var input = new TextBox
+        {
+            Text = initial,
+            SelectionStart = 0,
+            SelectionLength = initial.Length
+        };
+
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = input,
+            PrimaryButtonText = primaryText,
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        return await dialog.ShowAsync() is ContentDialogResult.Primary && !string.IsNullOrWhiteSpace(input.Text)
+            ? input.Text.Trim()
+            : null;
+    }
+
+    #endregion
+}

--- a/src/Sefirah/ViewModels/PhotosViewModel.cs
+++ b/src/Sefirah/ViewModels/PhotosViewModel.cs
@@ -1,0 +1,442 @@
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Security.Cryptography;
+using System.Text;
+using CommunityToolkit.WinUI;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Renci.SshNet;
+using Sefirah.Data.Models;
+using Sefirah.Utils;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+
+namespace Sefirah.ViewModels;
+
+/// <summary>
+/// A gallery of the images on the device, with the actions that make a phone gallery useful from a
+/// desktop: copy one into the clipboard, keep it, or throw it away.
+/// </summary>
+public sealed partial class PhotosViewModel : BaseViewModel
+{
+    #region Services
+    private readonly IDeviceManager DeviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly ISftpFeature SftpFeature = Ioc.Default.GetRequiredService<ISftpFeature>();
+    private readonly ISessionManager SessionManager = Ioc.Default.GetRequiredService<ISessionManager>();
+    #endregion
+
+    /// <summary>Where phones keep pictures. Anything else is a file, not a photo.</summary>
+    private static readonly string[] PhotoFolders = ["DCIM", "Pictures", "Download"];
+
+    private static readonly string[] PhotoExtensions =
+        [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic"];
+
+    private const int MaxPhotos = 60;
+    private const int MaxDepth = 2;
+    private const int HeadBytes = 256 * 1024;
+
+    /// <summary>Above this, a preview is not worth pulling the whole image across the network.</summary>
+    private const long PreviewSizeLimit = 8L * 1024 * 1024;
+
+    private readonly DeviceSftpConnection connection = new();
+    private readonly SemaphoreSlim loadLock = new(1, 1);
+
+    private CancellationTokenSource? previewCts;
+    private bool listening;
+    private string? boundDeviceId;
+
+    public ObservableCollection<RemotePhotoItem> Photos { get; } = [];
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsBusy { get; set; }
+
+    [ObservableProperty]
+    public partial string? StatusMessage { get; set; }
+
+    [ObservableProperty]
+    public partial RemotePhotoItem? SelectedPhoto { get; set; }
+
+    public bool HasStatus => !string.IsNullOrEmpty(StatusMessage);
+
+    partial void OnStatusMessageChanged(string? value) => OnPropertyChanged(nameof(HasStatus));
+
+    #region Lifetime
+
+    public async Task InitializeAsync()
+    {
+        if (!listening)
+        {
+            SftpFeature.SessionChanged += OnSessionChanged;
+            SessionManager.ConnectionStatusChanged += OnConnectionStatusChanged;
+            listening = true;
+        }
+
+        await LoadAsync();
+    }
+
+    public void Suspend()
+    {
+        if (listening)
+        {
+            SftpFeature.SessionChanged -= OnSessionChanged;
+            SessionManager.ConnectionStatusChanged -= OnConnectionStatusChanged;
+            listening = false;
+        }
+
+        previewCts?.Cancel();
+        connection.Drop();
+    }
+
+    private void OnSessionChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+
+        connection.Drop();
+        dispatcher.TryEnqueue(async () => await LoadAsync());
+    }
+
+    private void OnConnectionStatusChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+        if (device.IsConnected) return;
+
+        previewCts?.Cancel();
+        connection.Drop();
+        dispatcher.TryEnqueue(() =>
+        {
+            Photos.Clear();
+            StatusMessage = "PhotosDisconnected".GetLocalizedResource();
+        });
+    }
+
+    #endregion
+
+    #region Loading
+
+    [RelayCommand]
+    private Task Refresh() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        if (!await loadLock.WaitAsync(0)) return;
+
+        previewCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        previewCts = cts;
+
+        try
+        {
+            boundDeviceId = DeviceManager.ActiveDevice?.Id;
+            IsLoading = true;
+            StatusMessage = null;
+
+            var session = connection.CurrentSession();
+            if (session is null)
+            {
+                Photos.Clear();
+                StatusMessage = "PhotosUnavailable".GetLocalizedResource();
+                return;
+            }
+
+            var root = (session.Paths.Count > 0 ? session.Paths[0] : "/").TrimEnd('/');
+            var found = await connection.RunAsync(sftp =>
+            {
+                List<RemotePhotoItem> photos = [];
+                foreach (var folder in PhotoFolders)
+                {
+                    Collect(sftp, $"{root}/{folder}", 0, photos);
+                }
+                return photos
+                    .OrderByDescending(photo => photo.LastModified)
+                    .Take(MaxPhotos)
+                    .ToList();
+            });
+
+            Photos.Clear();
+            foreach (var photo in found)
+            {
+                Photos.Add(photo);
+            }
+
+            if (Photos.Count == 0)
+            {
+                StatusMessage = "PhotosEmpty".GetLocalizedResource();
+                return;
+            }
+
+            // Previews trickle in afterwards so the grid appears immediately
+            _ = LoadPreviewsAsync([.. found], cts.Token);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to list photos: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsLoading = false;
+            loadLock.Release();
+        }
+    }
+
+    private static void Collect(SftpClient sftp, string directory, int depth, List<RemotePhotoItem> into)
+    {
+        if (depth > MaxDepth) return;
+
+        try
+        {
+            foreach (var entry in sftp.ListDirectory(directory))
+            {
+                // Leading dots are thumbnails caches and trash, not the user's pictures
+                if (entry.Name is "." or ".." || entry.Name.StartsWith('.')) continue;
+
+                if (entry.IsDirectory)
+                {
+                    Collect(sftp, entry.FullName, depth + 1, into);
+                }
+                else if (PhotoExtensions.Contains(Path.GetExtension(entry.Name).ToLowerInvariant()))
+                {
+                    into.Add(new RemotePhotoItem
+                    {
+                        Name = entry.Name,
+                        FullPath = entry.FullName,
+                        Size = entry.Length,
+                        LastModified = entry.LastWriteTime
+                    });
+                }
+            }
+        }
+        catch
+        {
+            // A folder we cannot read is not worth failing the whole gallery over
+        }
+    }
+
+    private async Task LoadPreviewsAsync(IReadOnlyList<RemotePhotoItem> photos, CancellationToken token)
+    {
+        foreach (var photo in photos)
+        {
+            if (token.IsCancellationRequested) return;
+
+            try
+            {
+                var bytes = await FetchPreviewBytesAsync(photo, token);
+                if (bytes is null || token.IsCancellationRequested) continue;
+
+                await dispatcher.EnqueueAsync(async () =>
+                {
+                    var bitmap = new BitmapImage { DecodePixelWidth = 320 };
+                    using var stream = new InMemoryRandomAccessStream();
+                    await stream.WriteAsync(bytes.AsBuffer());
+                    stream.Seek(0);
+                    await bitmap.SetSourceAsync(stream);
+                    photo.Preview = bitmap;
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"No preview for {photo.Name}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the head of the image first: that is often the whole file, and for camera shots it
+    /// carries an embedded preview, which saves pulling megabytes for a thumbnail.
+    /// </summary>
+    private async Task<byte[]?> FetchPreviewBytesAsync(RemotePhotoItem photo, CancellationToken token)
+    {
+        var cached = CachePathFor(photo);
+
+        // Only trust a cached copy that is the whole picture; a partial one would render as a torn image
+        if (File.Exists(cached) && new FileInfo(cached).Length == photo.Size)
+        {
+            photo.LocalPath = cached;
+            return await File.ReadAllBytesAsync(cached, token);
+        }
+
+        return await connection.RunAsync<byte[]?>(sftp =>
+        {
+            // Small enough that reading the head means reading the whole picture
+            if (photo.Size <= HeadBytes)
+            {
+                var whole = new byte[photo.Size];
+                using (var stream = sftp.OpenRead(photo.FullPath))
+                {
+                    stream.ReadExactly(whole);
+                }
+
+                Cache(cached, whole);
+                photo.LocalPath = cached;
+                return whole;
+            }
+
+            var head = new byte[HeadBytes];
+            using (var stream = sftp.OpenRead(photo.FullPath))
+            {
+                // ReadExactly, because a single Read over the network returns whatever has arrived so far
+                stream.ReadExactly(head);
+            }
+
+            if (ExifThumbnail.TryExtract(head) is { } embedded) return embedded;
+
+            if (photo.Size > PreviewSizeLimit) return null;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(cached)!);
+            using (var file = File.Create(cached))
+            {
+                sftp.DownloadFile(photo.FullPath, file);
+            }
+
+            photo.LocalPath = cached;
+            return File.ReadAllBytes(cached);
+        });
+    }
+
+    private static void Cache(string path, byte[] bytes)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, bytes);
+    }
+
+    #endregion
+
+    #region Actions
+
+    [RelayCommand]
+    private async Task Open(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = await EnsureLocalCopyAsync(photo);
+            Process.Start(new ProcessStartInfo(local) { UseShellExecute = true });
+        });
+    }
+
+    [RelayCommand]
+    private async Task Copy(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = await EnsureLocalCopyAsync(photo);
+            var file = await StorageFile.GetFileFromPathAsync(local);
+
+            // Both forms: as a bitmap for editors, as a file for Explorer and chat apps
+            var package = new DataPackage { RequestedOperation = DataPackageOperation.Copy };
+            package.Properties.PackageFamilyName = Package.Current.Id.FamilyName;
+            package.SetBitmap(RandomAccessStreamReference.CreateFromFile(file));
+            package.SetStorageItems([file], false);
+            Clipboard.SetContent(package);
+
+            StatusMessage = null;
+        });
+    }
+
+    [RelayCommand]
+    private async Task Save(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        var folder = await PickerHelper.PickFolderAsync();
+        if (folder is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = await EnsureLocalCopyAsync(photo);
+            File.Copy(local, Path.Combine(folder.Path, photo.Name), overwrite: true);
+        });
+    }
+
+    [RelayCommand]
+    private async Task Delete(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        var dialog = new ContentDialog
+        {
+            Title = "PhotosDeleteTitle".GetLocalizedResource(),
+            Content = string.Format("PhotosDeleteSubtitle".GetLocalizedResource(), photo.Name),
+            PrimaryButtonText = "Remove".GetLocalizedResource(),
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        if (await dialog.ShowAsync() is not ContentDialogResult.Primary) return;
+
+        await RunAsync(async () =>
+        {
+            await connection.RunAsync(sftp => { sftp.DeleteFile(photo.FullPath); return true; });
+            Photos.Remove(photo);
+
+            if (Photos.Count == 0)
+            {
+                StatusMessage = "PhotosEmpty".GetLocalizedResource();
+            }
+        });
+    }
+
+    private async Task<string> EnsureLocalCopyAsync(RemotePhotoItem photo)
+    {
+        var cached = CachePathFor(photo);
+        if (photo.LocalPath is { } existing && File.Exists(existing) && new FileInfo(existing).Length == photo.Size)
+        {
+            return existing;
+        }
+
+        await connection.RunAsync(sftp =>
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(cached)!);
+            using var file = File.Create(cached);
+            sftp.DownloadFile(photo.FullPath, file);
+            return true;
+        });
+
+        photo.LocalPath = cached;
+        return cached;
+    }
+
+    /// <summary>
+    /// Keyed on the full remote path so two pictures with the same name never collide.
+    /// </summary>
+    private static string CachePathFor(RemotePhotoItem photo)
+    {
+        var digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(photo.FullPath)))[..12];
+        return Path.Combine(Path.GetTempPath(), "Sefirah", "photos", $"{digest}_{photo.Name}");
+    }
+
+    private async Task RunAsync(Func<Task> operation)
+    {
+        if (IsBusy) return;
+
+        IsBusy = true;
+        try
+        {
+            await operation();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Photo action failed: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static string Describe(Exception ex) => ex switch
+    {
+        InvalidOperationException => "PhotosUnavailable".GetLocalizedResource(),
+        _ when DeviceSftpConnection.IsUnreachable(ex) => "PhotosDisconnected".GetLocalizedResource(),
+        _ => ex.Message
+    };
+
+    #endregion
+}

--- a/src/Sefirah/ViewModels/Settings/DevicesViewModel.cs
+++ b/src/Sefirah/ViewModels/Settings/DevicesViewModel.cs
@@ -16,6 +16,7 @@ public partial class DevicesViewModel : ObservableObject
     private SmsRepository SmsRepository { get; } = Ioc.Default.GetRequiredService<SmsRepository>();
     private CallLogRepository CallLogRepository { get; } = Ioc.Default.GetRequiredService<CallLogRepository>();
     private NotificationRepository NotificationRepository { get; } = Ioc.Default.GetRequiredService<NotificationRepository>();
+    private ClipboardRepository ClipboardRepository { get; } = Ioc.Default.GetRequiredService<ClipboardRepository>();
     #endregion
     
     public ObservableCollection<PairedDevice> PairedDevices => DeviceManager.PairedDevices;
@@ -91,6 +92,7 @@ public partial class DevicesViewModel : ObservableObject
                 ContactRepository.DeleteAllContactsForDevice(deviceId);
                 CallLogRepository.DeleteAllCallLogsForDevice(deviceId);
                 NotificationRepository.RemoveNotificationsForDevice(deviceId);
+                ClipboardRepository.DeleteAllForDevice(deviceId);
             });
         }
         catch (Exception ex)

--- a/src/Sefirah/Views/ClipboardPage.xaml
+++ b/src/Sefirah/Views/ClipboardPage.xaml
@@ -1,0 +1,172 @@
+﻿<Page
+    x:Class="Sefirah.Views.ClipboardPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Sefirah.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Sefirah.Helpers"
+    xmlns:local="using:Sefirah.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Sefirah.Data.Models"
+    xmlns:vm="using:Sefirah.ViewModels"
+    x:Name="ClipboardPageRoot"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:BooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" Inverse="True" />
+
+        <DataTemplate x:Key="ClipboardEntryTemplate" x:DataType="models:ClipboardEntry">
+            <Grid
+                Padding="12"
+                Background="Transparent"
+                ColumnSpacing="12"
+                IsRightTapEnabled="True">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Grid.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem
+                            Click="CopyEntryClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=ClipboardCopy}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8C8;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="DeleteEntryClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=Remove}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74D;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </Grid.ContextFlyout>
+
+                <!--  Image entries show the picture, text entries an icon  -->
+                <Border
+                    Grid.Column="0"
+                    Width="64"
+                    Height="64"
+                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                    CornerRadius="4">
+                    <Grid>
+                        <FontIcon
+                            FontSize="20"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Glyph="&#xE8C8;"
+                            Visibility="{x:Bind IsImage, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                        <Image
+                            Source="{x:Bind Thumbnail}"
+                            Stretch="UniformToFill"
+                            Visibility="{x:Bind IsImage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    </Grid>
+                </Border>
+
+                <StackPanel
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Spacing="4">
+                    <TextBlock
+                        MaxLines="3"
+                        Text="{x:Bind Preview}"
+                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{x:Bind TimestampText}" />
+                </StackPanel>
+
+                <Button
+                    Grid.Column="2"
+                    VerticalAlignment="Center"
+                    Click="CopyEntryClick"
+                    DataContext="{x:Bind}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=ClipboardCopy}">
+                    <FontIcon FontSize="14" Glyph="&#xE8C8;" />
+                </Button>
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{helpers:ResourceString Name=ClipboardHistory}" />
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{helpers:ResourceString Name=ClipboardHistorySubtitle}"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel
+                Grid.Column="1"
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    Command="{x:Bind ViewModel.ClearCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=ClipboardClearTitle}">
+                    <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.RefreshCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesRefresh}">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="1">
+            <ListView
+                x:Name="EntriesListView"
+                IsItemClickEnabled="True"
+                ItemClick="EntriesListView_ItemClick"
+                ItemTemplate="{StaticResource ClipboardEntryTemplate}"
+                ItemsSource="{x:Bind ViewModel.Entries}"
+                SelectedItem="{x:Bind ViewModel.SelectedEntry, Mode=TwoWay}"
+                SelectionMode="Single">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+            </ListView>
+
+            <TextBlock
+                MaxWidth="420"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Visibility="{x:Bind ViewModel.HasStatus, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <ProgressRing
+                Width="32"
+                Height="32"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+        </Grid>
+    </Grid>
+</Page>

--- a/src/Sefirah/Views/ClipboardPage.xaml.cs
+++ b/src/Sefirah/Views/ClipboardPage.xaml.cs
@@ -1,0 +1,55 @@
+using Sefirah.Data.Models;
+using Sefirah.ViewModels;
+
+namespace Sefirah.Views;
+
+public sealed partial class ClipboardPage : Page
+{
+    public ClipboardViewModel ViewModel { get; }
+
+    public ClipboardPage()
+    {
+        InitializeComponent();
+        ViewModel = Ioc.Default.GetRequiredService<ClipboardViewModel>();
+
+        Loaded += ClipboardPage_Loaded;
+        Unloaded += ClipboardPage_Unloaded;
+    }
+
+    private async void ClipboardPage_Loaded(object sender, RoutedEventArgs e)
+        => await ViewModel.InitializeAsync();
+
+    private void ClipboardPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= ClipboardPage_Loaded;
+        Unloaded -= ClipboardPage_Unloaded;
+        ViewModel.Suspend();
+    }
+
+    private async void EntriesListView_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is ClipboardEntry entry)
+        {
+            await ViewModel.CopyCommand.ExecuteAsync(entry);
+        }
+    }
+
+    private async void CopyEntryClick(object sender, RoutedEventArgs e)
+    {
+        if (GetEntry(sender) is ClipboardEntry entry)
+        {
+            await ViewModel.CopyCommand.ExecuteAsync(entry);
+        }
+    }
+
+    private async void DeleteEntryClick(object sender, RoutedEventArgs e)
+    {
+        if (GetEntry(sender) is ClipboardEntry entry)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(entry);
+        }
+    }
+
+    private static ClipboardEntry? GetEntry(object sender)
+        => (sender as FrameworkElement)?.DataContext as ClipboardEntry;
+}

--- a/src/Sefirah/Views/FilesPage.xaml
+++ b/src/Sefirah/Views/FilesPage.xaml
@@ -1,0 +1,202 @@
+﻿<Page
+    x:Class="Sefirah.Views.FilesPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Sefirah.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Sefirah.Helpers"
+    xmlns:local="using:Sefirah.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Sefirah.Data.Models"
+    xmlns:vm="using:Sefirah.ViewModels"
+    x:Name="FilesPageRoot"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+        <DataTemplate x:Key="FileItemTemplate" x:DataType="models:RemoteFileItem">
+            <Grid
+                Padding="4,6"
+                ColumnSpacing="12"
+                Background="Transparent"
+                IsRightTapEnabled="True"
+                ToolTipService.ToolTip="{x:Bind Name}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Grid.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem
+                            Click="OpenItemClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=FilesOpen}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8E5;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="DownloadItemClick"
+                            DataContext="{x:Bind}"
+                            IsEnabled="{x:Bind IsFile}"
+                            Text="{helpers:ResourceString Name=FilesDownload}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE896;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem
+                            Click="RenameItemClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=FilesRename}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8AC;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="DeleteItemClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=Remove}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74D;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </Grid.ContextFlyout>
+
+                <FontIcon
+                    Grid.Column="0"
+                    FontSize="18"
+                    Glyph="{x:Bind Glyph}" />
+
+                <TextBlock
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Text="{x:Bind Name}"
+                    TextTrimming="CharacterEllipsis" />
+
+                <TextBlock
+                    Grid.Column="2"
+                    MinWidth="90"
+                    VerticalAlignment="Center"
+                    HorizontalTextAlignment="Right"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{x:Bind SizeText}" />
+
+                <TextBlock
+                    Grid.Column="3"
+                    MinWidth="130"
+                    VerticalAlignment="Center"
+                    HorizontalTextAlignment="Right"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{x:Bind LastModifiedText}" />
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!--  Path and actions  -->
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button
+                Grid.Column="0"
+                Command="{x:Bind ViewModel.GoUpCommand}"
+                IsEnabled="{x:Bind ViewModel.CanGoUp, Mode=OneWay}"
+                ToolTipService.ToolTip="{helpers:ResourceString Name=FilesGoUp}">
+                <FontIcon FontSize="14" Glyph="&#xE74A;" />
+            </Button>
+
+            <BreadcrumbBar
+                x:Name="PathBreadcrumbBar"
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                ItemsSource="{x:Bind ViewModel.PathSegments, Mode=OneWay}" />
+
+            <StackPanel
+                Grid.Column="2"
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    Command="{x:Bind ViewModel.NewFolderCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesNewFolder}">
+                    <FontIcon FontSize="14" Glyph="&#xE8F4;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.UploadCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesUpload}">
+                    <FontIcon FontSize="14" Glyph="&#xE898;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.RefreshCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesRefresh}">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <!--  Volume picker, only worth showing when the device exposes more than one  -->
+        <ComboBox
+            Grid.Row="1"
+            MinWidth="200"
+            ItemsSource="{x:Bind ViewModel.Volumes, Mode=OneWay}"
+            SelectedIndex="{x:Bind ViewModel.SelectedVolumeIndex, Mode=TwoWay}"
+            Visibility="{x:Bind ViewModel.HasMultipleVolumes, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+        <Grid Grid.Row="2">
+            <ListView
+                x:Name="FilesListView"
+                IsItemClickEnabled="True"
+                ItemClick="FilesListView_ItemClick"
+                ItemTemplate="{StaticResource FileItemTemplate}"
+                ItemsSource="{x:Bind ViewModel.Items}"
+                SelectionMode="Single">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+            </ListView>
+
+            <TextBlock
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                MaxWidth="420"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Visibility="{x:Bind ViewModel.HasStatus, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <ProgressRing
+                Width="32"
+                Height="32"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+        </Grid>
+
+        <ProgressBar
+            Grid.Row="2"
+            VerticalAlignment="Top"
+            IsIndeterminate="True"
+            Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+    </Grid>
+</Page>

--- a/src/Sefirah/Views/FilesPage.xaml.cs
+++ b/src/Sefirah/Views/FilesPage.xaml.cs
@@ -1,0 +1,76 @@
+using Sefirah.Data.Models;
+using Sefirah.ViewModels;
+
+namespace Sefirah.Views;
+
+public sealed partial class FilesPage : Page
+{
+    public FilesViewModel ViewModel { get; }
+
+    public FilesPage()
+    {
+        InitializeComponent();
+        ViewModel = Ioc.Default.GetRequiredService<FilesViewModel>();
+
+        PathBreadcrumbBar.ItemClicked += PathBreadcrumbBar_ItemClicked;
+        Loaded += FilesPage_Loaded;
+        Unloaded += FilesPage_Unloaded;
+    }
+
+    private async void FilesPage_Loaded(object sender, RoutedEventArgs e)
+        => await ViewModel.InitializeAsync();
+
+    private void FilesPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        PathBreadcrumbBar.ItemClicked -= PathBreadcrumbBar_ItemClicked;
+        Loaded -= FilesPage_Loaded;
+        Unloaded -= FilesPage_Unloaded;
+        ViewModel.Suspend();
+    }
+
+    private async void PathBreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
+        => await ViewModel.NavigateToSegmentAsync(args.Index);
+
+    private async void FilesListView_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is RemoteFileItem item)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void OpenItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void DownloadItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.DownloadCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void RenameItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.RenameCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void DeleteItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(item);
+        }
+    }
+
+    private static RemoteFileItem? GetItem(object sender)
+        => (sender as FrameworkElement)?.DataContext as RemoteFileItem;
+}

--- a/src/Sefirah/Views/MainPage.xaml
+++ b/src/Sefirah/Views/MainPage.xaml
@@ -219,6 +219,36 @@
                                 <FontIcon Glyph="&#xED35;" />
                             </NavigationViewItem.Icon>
                         </NavigationViewItem>
+
+                        <NavigationViewItem
+                            x:Name="FilesNavigationItem"
+                            Content="{helpers:ResourceString Name=Files}"
+                            Tag="Files"
+                            Visibility="{x:Bind ViewModel.Device, Converter={StaticResource EmptyObjectToVisibilityConverter}, Mode=OneWay}">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xE8B7;" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
+
+                        <NavigationViewItem
+                            x:Name="PhotosNavigationItem"
+                            Content="{helpers:ResourceString Name=Photos}"
+                            Tag="Photos"
+                            Visibility="{x:Bind ViewModel.Device, Converter={StaticResource EmptyObjectToVisibilityConverter}, Mode=OneWay}">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xEB9F;" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
+
+                        <NavigationViewItem
+                            x:Name="ClipboardNavigationItem"
+                            Content="{helpers:ResourceString Name=ClipboardHistory}"
+                            Tag="Clipboard"
+                            Visibility="{x:Bind ViewModel.Device, Converter={StaticResource EmptyObjectToVisibilityConverter}, Mode=OneWay}">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xE8C8;" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
                     </NavigationView.MenuItems>
 
                     <NavigationView.FooterMenuItems>

--- a/src/Sefirah/Views/MainPage.xaml.cs
+++ b/src/Sefirah/Views/MainPage.xaml.cs
@@ -16,7 +16,10 @@ public sealed partial class MainPage : Page
         { "Settings", typeof(SettingsPage) },
         { "Calls", typeof(CallsPage) },
         { "Messages", typeof(MessagesPage) },
-        { "Apps", typeof(AppsPage) }
+        { "Apps", typeof(AppsPage) },
+        { "Files", typeof(FilesPage) },
+        { "Photos", typeof(PhotosPage) },
+        { "Clipboard", typeof(ClipboardPage) }
     };
 
     public MainPage()
@@ -61,6 +64,9 @@ public sealed partial class MainPage : Page
             "Calls" => CallsNavigationItem,
             "Messages" => MessagesNavigationItem,
             "Apps" => AppsNavigationItem,
+            "Files" => FilesNavigationItem,
+            "Photos" => PhotosNavigationItem,
+            "Clipboard" => ClipboardNavigationItem,
             "Settings" => MainNavigationView.SettingsItem,
             _ => MainNavigationView.SelectedItem
         };

--- a/src/Sefirah/Views/PhotosPage.xaml
+++ b/src/Sefirah/Views/PhotosPage.xaml
@@ -1,0 +1,168 @@
+﻿<Page
+    x:Class="Sefirah.Views.PhotosPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Sefirah.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Sefirah.Helpers"
+    xmlns:local="using:Sefirah.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Sefirah.Data.Models"
+    xmlns:vm="using:Sefirah.ViewModels"
+    x:Name="PhotosPageRoot"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:EmptyObjectToVisibilityConverter x:Key="NoPreviewToVisibilityConverter" Inverse="True" />
+
+        <DataTemplate x:Key="PhotoTemplate" x:DataType="models:RemotePhotoItem">
+            <Grid
+                Width="170"
+                Height="170"
+                Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                CornerRadius="6"
+                IsRightTapEnabled="True"
+                ToolTipService.ToolTip="{x:Bind Tooltip}">
+
+                <Grid.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem
+                            Click="OpenPhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=PhotosOpen}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8E5;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="CopyPhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=PhotosCopy}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8C8;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="SavePhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=PhotosSave}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74E;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem
+                            Click="DeletePhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=Remove}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74D;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </Grid.ContextFlyout>
+
+                <!--  Stands in until the preview arrives  -->
+                <FontIcon
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    FontSize="28"
+                    Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                    Glyph="&#xEB9F;"
+                    Visibility="{x:Bind Preview, Mode=OneWay, Converter={StaticResource NoPreviewToVisibilityConverter}}" />
+
+                <Image
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Source="{x:Bind Preview, Mode=OneWay}"
+                    Stretch="UniformToFill" />
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!--  Actions on the selected picture  -->
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{helpers:ResourceString Name=PhotosRecent}" />
+
+            <StackPanel
+                Grid.Column="1"
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    Command="{x:Bind ViewModel.CopyCommand}"
+                    CommandParameter="{x:Bind ViewModel.SelectedPhoto, Mode=OneWay}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=PhotosCopy}">
+                    <FontIcon FontSize="14" Glyph="&#xE8C8;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.SaveCommand}"
+                    CommandParameter="{x:Bind ViewModel.SelectedPhoto, Mode=OneWay}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=PhotosSave}">
+                    <FontIcon FontSize="14" Glyph="&#xE74E;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.DeleteCommand}"
+                    CommandParameter="{x:Bind ViewModel.SelectedPhoto, Mode=OneWay}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Remove}">
+                    <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.RefreshCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesRefresh}">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="1">
+            <GridView
+                x:Name="PhotosGridView"
+                IsItemClickEnabled="True"
+                ItemClick="PhotosGridView_ItemClick"
+                ItemTemplate="{StaticResource PhotoTemplate}"
+                ItemsSource="{x:Bind ViewModel.Photos}"
+                SelectedItem="{x:Bind ViewModel.SelectedPhoto, Mode=TwoWay}"
+                SelectionMode="Single" />
+
+            <TextBlock
+                MaxWidth="420"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Visibility="{x:Bind ViewModel.HasStatus, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <ProgressRing
+                Width="32"
+                Height="32"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+        </Grid>
+
+        <ProgressBar
+            Grid.Row="1"
+            VerticalAlignment="Top"
+            IsIndeterminate="True"
+            Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+    </Grid>
+</Page>

--- a/src/Sefirah/Views/PhotosPage.xaml.cs
+++ b/src/Sefirah/Views/PhotosPage.xaml.cs
@@ -1,0 +1,71 @@
+using Sefirah.Data.Models;
+using Sefirah.ViewModels;
+
+namespace Sefirah.Views;
+
+public sealed partial class PhotosPage : Page
+{
+    public PhotosViewModel ViewModel { get; }
+
+    public PhotosPage()
+    {
+        InitializeComponent();
+        ViewModel = Ioc.Default.GetRequiredService<PhotosViewModel>();
+
+        Loaded += PhotosPage_Loaded;
+        Unloaded += PhotosPage_Unloaded;
+    }
+
+    private async void PhotosPage_Loaded(object sender, RoutedEventArgs e)
+        => await ViewModel.InitializeAsync();
+
+    private void PhotosPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= PhotosPage_Loaded;
+        Unloaded -= PhotosPage_Unloaded;
+        ViewModel.Suspend();
+    }
+
+    private async void PhotosGridView_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is RemotePhotoItem photo)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void OpenPhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void CopyPhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.CopyCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void SavePhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.SaveCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void DeletePhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private static RemotePhotoItem? GetPhoto(object sender)
+        => (sender as FrameworkElement)?.DataContext as RemotePhotoItem;
+}


### PR DESCRIPTION
Three pages next to Apps, all reading the device over the SFTP endpoint it already announces while connected. They do not depend on the platform having mounted that endpoint, so they work even when the sync root failed to register or the shell integration is off.

### Files

A browser for the device filesystem: breadcrumb navigation, folders first, size and date. Opening a file streams it to a temp copy and hands it to the default application. Save to PC, send a file to the current folder, rename, delete and new folder are on the context menu and the toolbar. Deleting goes through the device's own recycle bin, since its SFTP server intercepts removal.

If the device exposes several volumes a picker appears; with one it stays hidden.

### Photos

The most recent pictures from `DCIM`, `Pictures` and `Download`, newest first, with copy to clipboard, save to PC and delete.

The interesting part is the previews. Pulling whole images across the network for a thumbnail grid is not viable, so each file is read 256 KB at a time and the preview cameras embed in EXIF is used when there is one. Measured on a Pixel 7 Pro over Wi-Fi:

```
6987 pictures found in 2.5s
of the 40 most recent: 11 carry an EXIF thumbnail, 210 KB in total
the remaining 29 (screenshots, PNGs, chat images) weigh 20 MB together
reading the heads of all 40: 1.3s
```

So the embedded preview is used when present, the whole file only when it is under 8 MB, and anything larger keeps a placeholder until it is opened. Everything is cached under the temp folder keyed by a hash of the remote path, and a cached copy is only trusted when its length matches the remote size.

Copying puts the picture on the clipboard in both forms: a bitmap for editors and chat apps, and a file for Explorer.

### Clipboard

Android exposes no clipboard history of its own - the system holds one item and the keyboard's history is private to it. So this records what the device sends as it arrives, keeping the last 200 entries per device in a new `ClipboardEntity` table, text and images alike. Clicking an entry puts it back on the Windows clipboard.

Incoming clipboard images live in the temporary folder, which is pruned daily, so history entries copy them somewhere that outlives that. Trimming past 200 removes the stored image with the row, and removing a device clears its history.

This changes nothing about the existing behaviour: items still land on the Windows clipboard as they arrive, and the page is a record you can reach back into.

### Shared plumbing

The SFTP connection is in one place, `DeviceSftpConnection`, rather than duplicated per page. It offers password authentication and a throwaway key, because the announced password goes stale the moment the device restarts its server and the device accepts any public key; and it reconnects once when a call fails on a connection that had been alive, which is what happens every time the device leaves the network.

Two contract additions support this: `ISftpFeature.GetSession` and `SessionChanged` let a page find the endpoint and rebuild when a new one is announced, and `IClipboardFeature.HistoryChanged` lets the clipboard page update live.

### Testing

Windows 11, Pixel 7 Pro on Android 17, over Wi-Fi and over a VPN.

Browsing, opening, uploading, renaming, deleting and creating folders all exercised; photo previews verified against the numbers above, including copy, save and delete; clipboard history verified for text and for images, and confirmed to survive a restart.

Built clean against master, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
