### PR TITLE
Add the Italian translation, and fix the system-language entry in the picker

### DIFF
--- a/src/Sefirah/Data/AppDatabase/DatabaseContext.cs
+++ b/src/Sefirah/Data/AppDatabase/DatabaseContext.cs
@@ -122,6 +122,7 @@ public class DatabaseContext
         db.CreateTable<AttachmentEntity>();
         db.CreateTable<CallLogEntity>();
         db.CreateTable<NotificationEntity>();
+        db.CreateTable<ClipboardEntity>();
     }
 
     public static void DropAllTables(SQLiteConnection db)

--- a/src/Sefirah/Data/AppDatabase/Models/ClipboardEntity.cs
+++ b/src/Sefirah/Data/AppDatabase/Models/ClipboardEntity.cs
@@ -1,0 +1,26 @@
+using SQLite;
+
+namespace Sefirah.Data.AppDatabase.Models;
+
+/// <summary>
+/// One thing the device put on its clipboard. Android keeps no history of its own, so this table
+/// is the only record of what was copied before the current item.
+/// </summary>
+public class ClipboardEntity
+{
+    [PrimaryKey, AutoIncrement]
+    public int Id { get; set; }
+
+    [Indexed]
+    public string DeviceId { get; set; } = string.Empty;
+
+    /// <summary>Mime type as the device reported it, or text/plain for plain text.</summary>
+    public string ClipboardType { get; set; } = string.Empty;
+
+    /// <summary>The text itself, or the path of the stored image.</summary>
+    public string Content { get; set; } = string.Empty;
+
+    public bool IsImage { get; set; }
+
+    public long TimestampMillis { get; set; }
+}

--- a/src/Sefirah/Data/AppDatabase/Repository/ClipboardRepository.cs
+++ b/src/Sefirah/Data/AppDatabase/Repository/ClipboardRepository.cs
@@ -1,0 +1,109 @@
+using Sefirah.Data.AppDatabase.Models;
+using Sefirah.Data.Models;
+using Sefirah.Utils;
+
+namespace Sefirah.Data.AppDatabase.Repository;
+
+public class ClipboardRepository(DatabaseContext context)
+{
+    /// <summary>
+    /// How much history to keep per device. Past this the oldest entries go, along with their images.
+    /// </summary>
+    private const int MaxEntries = 200;
+
+    public Task SaveAsync(string deviceId, string clipboardType, string content, bool isImage) =>
+        Task.Run(() =>
+        {
+            if (string.IsNullOrEmpty(content)) return;
+
+            // The device re-sends the current clipboard on every reconnect; no point stacking duplicates
+            var latest = context.Database.Table<ClipboardEntity>()
+                .Where(entry => entry.DeviceId == deviceId)
+                .OrderByDescending(entry => entry.TimestampMillis)
+                .FirstOrDefault();
+
+            if (latest is not null && latest.IsImage == isImage && latest.Content == content) return;
+
+            context.Database.Insert(new ClipboardEntity
+            {
+                DeviceId = deviceId,
+                ClipboardType = clipboardType,
+                Content = content,
+                IsImage = isImage,
+                TimestampMillis = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            });
+
+            Trim(deviceId);
+        });
+
+    public async Task<List<ClipboardEntry>> GetEntriesAsync(string deviceId)
+    {
+        var entities = await Task.Run(() =>
+            context.Database.Table<ClipboardEntity>()
+                .Where(entry => entry.DeviceId == deviceId)
+                .OrderByDescending(entry => entry.TimestampMillis)
+                .ToList());
+
+        return [.. entities.Select(ToEntry)];
+    }
+
+    public Task DeleteAsync(int id) =>
+        Task.Run(() =>
+        {
+            var entity = context.Database.Find<ClipboardEntity>(id);
+            if (entity is null) return;
+
+            DeleteImage(entity);
+            context.Database.Delete<ClipboardEntity>(id);
+        });
+
+    public Task ClearAsync(string deviceId) =>
+        Task.Run(() => DeleteAllForDevice(deviceId));
+
+    public void DeleteAllForDevice(string deviceId)
+    {
+        foreach (var entity in context.Database.Table<ClipboardEntity>().Where(entry => entry.DeviceId == deviceId).ToList())
+        {
+            DeleteImage(entity);
+        }
+        context.Database.Table<ClipboardEntity>().Delete(entry => entry.DeviceId == deviceId);
+    }
+
+    private void Trim(string deviceId)
+    {
+        var stale = context.Database.Table<ClipboardEntity>()
+            .Where(entry => entry.DeviceId == deviceId)
+            .OrderByDescending(entry => entry.TimestampMillis)
+            .Skip(MaxEntries)
+            .ToList();
+
+        foreach (var entity in stale)
+        {
+            DeleteImage(entity);
+            context.Database.Delete<ClipboardEntity>(entity.Id);
+        }
+    }
+
+    private static void DeleteImage(ClipboardEntity entity)
+    {
+        if (!entity.IsImage) return;
+
+        try
+        {
+            if (File.Exists(entity.Content)) File.Delete(entity.Content);
+        }
+        catch
+        {
+            // A leftover image is harmless, a crash while pruning is not
+        }
+    }
+
+    private static ClipboardEntry ToEntry(ClipboardEntity entity) => new()
+    {
+        Id = entity.Id,
+        ClipboardType = entity.ClipboardType,
+        Content = entity.Content,
+        IsImage = entity.IsImage,
+        Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(entity.TimestampMillis).LocalDateTime
+    };
+}

--- a/src/Sefirah/Data/Contracts/IClipboardFeature.cs
+++ b/src/Sefirah/Data/Contracts/IClipboardFeature.cs
@@ -5,6 +5,11 @@ namespace Sefirah.Data.Contracts;
 public interface IClipboardFeature : IFeature
 {
     /// <summary>
+    /// Raised once a new item from the device has been added to the history.
+    /// </summary>
+    event EventHandler<PairedDevice>? HistoryChanged;
+
+    /// <summary>
     /// Sets the clipboard from a remote
     /// </summary>
     Task SetContentAsync(ClipboardInfo clipboard, PairedDevice sourceDevice);

--- a/src/Sefirah/Data/Contracts/ISftpFeature.cs
+++ b/src/Sefirah/Data/Contracts/ISftpFeature.cs
@@ -19,6 +19,17 @@ public interface ISftpFeature : IFeature
     /// </summary>
     Task BrowseUriAsync(PairedDevice device);
 
+    /// <summary>
+    /// Raised when a device announces an SFTP endpoint. The device generates fresh credentials every
+    /// time its server restarts, so anything holding a connection has to rebuild it.
+    /// </summary>
+    event EventHandler<PairedDevice>? SessionChanged;
+
+    /// <summary>
+    /// Returns the SFTP endpoint the device is currently serving, or null when it has not announced one.
+    /// </summary>
+    SftpSession? GetSession(string deviceId);
+
     void Remove(string deviceId);
 
     Task RemoveAll();

--- a/src/Sefirah/Data/Models/ClipboardEntry.cs
+++ b/src/Sefirah/Data/Models/ClipboardEntry.cs
@@ -1,0 +1,50 @@
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// A past clipboard item from the device, as shown in the history.
+/// </summary>
+public sealed class ClipboardEntry
+{
+    public int Id { get; init; }
+
+    public required string ClipboardType { get; init; }
+
+    /// <summary>The text itself, or the path of the stored image.</summary>
+    public required string Content { get; init; }
+
+    public bool IsImage { get; init; }
+
+    public DateTime Timestamp { get; init; }
+
+    public bool IsText => !IsImage;
+
+    private ImageSource? thumbnail;
+
+    /// <summary>
+    /// Exposed as an ImageSource rather than a path: binding a string leaves WinUI to convert it,
+    /// and it refuses both an empty string and a null, taking the app down with it.
+    /// </summary>
+    public ImageSource? Thumbnail
+    {
+        get
+        {
+            if (thumbnail is not null) return thumbnail;
+            if (!IsImage || !File.Exists(Content)) return null;
+
+            var bitmap = new BitmapImage { DecodePixelWidth = 128 };
+            bitmap.UriSource = new Uri(Content);
+            thumbnail = bitmap;
+            return thumbnail;
+        }
+    }
+
+    /// <summary>Kept to a couple of lines: the list is for recognising an item, not reading it.</summary>
+    public string Preview => IsImage
+        ? Path.GetFileName(Content)
+        : Content.Length > 220 ? string.Concat(Content.AsSpan(0, 220), "…") : Content;
+
+    public string TimestampText => Timestamp.ToString("g");
+}

--- a/src/Sefirah/Data/Models/RemoteFileItem.cs
+++ b/src/Sefirah/Data/Models/RemoteFileItem.cs
@@ -1,0 +1,52 @@
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// An entry in the device filesystem, as listed over SFTP.
+/// </summary>
+public sealed class RemoteFileItem
+{
+    public required string Name { get; init; }
+
+    public required string FullPath { get; init; }
+
+    public bool IsDirectory { get; init; }
+
+    public bool IsFile => !IsDirectory;
+
+    public long Size { get; init; }
+
+    public DateTime LastModified { get; init; }
+
+    /// <summary>
+    /// Segoe Fluent Icons code point, the same icon family the rest of the app draws from.
+    /// </summary>
+    public string Glyph => ((char)(IsDirectory ? 0xE8B7 : GlyphFor(Path.GetExtension(Name)))).ToString();
+
+    public string SizeText => IsDirectory ? string.Empty : FormatSize(Size);
+
+    public string LastModifiedText => LastModified == default ? string.Empty : LastModified.ToString("g");
+
+    private static int GlyphFor(string extension) => extension.ToLowerInvariant() switch
+    {
+        ".jpg" or ".jpeg" or ".png" or ".gif" or ".bmp" or ".webp" or ".heic" => 0xEB9F,
+        ".mp4" or ".mkv" or ".avi" or ".mov" or ".webm" or ".3gp" => 0xE714,
+        ".mp3" or ".wav" or ".flac" or ".ogg" or ".m4a" or ".opus" => 0xE189,
+        ".zip" or ".rar" or ".7z" or ".tar" or ".gz" => 0xF12B,
+        ".apk" => 0xECAA,
+        ".pdf" or ".txt" or ".md" or ".log" or ".json" or ".xml" or ".doc" or ".docx" => 0xE8A5,
+        _ => 0xE7C3
+    };
+
+    private static string FormatSize(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        double size = bytes;
+        var unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+        return unit == 0 ? $"{bytes} {units[0]}" : $"{size:0.#} {units[unit]}";
+    }
+}

--- a/src/Sefirah/Data/Models/RemotePhotoItem.cs
+++ b/src/Sefirah/Data/Models/RemotePhotoItem.cs
@@ -1,0 +1,41 @@
+using Microsoft.UI.Xaml.Media.Imaging;
+
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// An image on the device, shown in the gallery. The preview and the local copy fill in as they
+/// are fetched, which is why they are observable rather than set once.
+/// </summary>
+public sealed partial class RemotePhotoItem : ObservableObject
+{
+    public required string Name { get; init; }
+
+    public required string FullPath { get; init; }
+
+    public long Size { get; init; }
+
+    public DateTime LastModified { get; init; }
+
+    [ObservableProperty]
+    public partial BitmapImage? Preview { get; set; }
+
+    /// <summary>
+    /// Set once the full image has been pulled down and cached, so later actions skip the transfer.
+    /// </summary>
+    public string? LocalPath { get; set; }
+
+    public string Tooltip => $"{Name}{Environment.NewLine}{LastModified:g}   {FormatSize(Size)}";
+
+    private static string FormatSize(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB"];
+        double size = bytes;
+        var unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+        return unit == 0 ? $"{bytes} {units[0]}" : $"{size:0.#} {units[unit]}";
+    }
+}

--- a/src/Sefirah/Data/Models/SftpSession.cs
+++ b/src/Sefirah/Data/Models/SftpSession.cs
@@ -1,0 +1,12 @@
+namespace Sefirah.Data.Models;
+
+/// <summary>
+/// The SFTP endpoint a connected device is currently serving, as announced in <see cref="SftpServerInfo"/>.
+/// </summary>
+public sealed record SftpSession(
+    string Host,
+    int Port,
+    string Username,
+    string Password,
+    IReadOnlyList<string> Paths,
+    IReadOnlyList<string> PathNames);

--- a/src/Sefirah/Features/ClipboardFeature.cs
+++ b/src/Sefirah/Features/ClipboardFeature.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.WinUI;
+using Sefirah.Data.AppDatabase.Repository;
 using Sefirah.Data.Models;
 using Sefirah.Utils;
 using Windows.ApplicationModel.DataTransfer;
@@ -13,7 +14,8 @@ public class ClipboardFeature(
     ISessionManager sessionManager,
     IPlatformNotificationHandler platformNotificationHandler,
     IDeviceManager deviceManager,
-    IFileTransferService fileTransferService) : IClipboardFeature
+    IFileTransferService fileTransferService,
+    ClipboardRepository clipboardRepository) : IClipboardFeature
 {
     private readonly DispatcherQueue dispatcher = App.MainWindow.DispatcherQueue;
     private bool isMonitoring = false;
@@ -35,6 +37,8 @@ public class ClipboardFeature(
     };
     
     private bool isInternalUpdate; // To track if the clipboard change came from the remote device
+
+    public event EventHandler<PairedDevice>? HistoryChanged;
 
     public Task InitializeAsync()
     {
@@ -233,6 +237,8 @@ public class ClipboardFeature(
 
     public async Task SetContentAsync(object content, PairedDevice sourceDevice)
     {
+        await RecordHistoryAsync(content, sourceDevice);
+
         if (!sourceDevice.DeviceSettings.ClipboardReceive) return;
 
         await dispatcher.EnqueueAsync(async () =>
@@ -290,6 +296,39 @@ public class ClipboardFeature(
                 dispatcher.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () => isInternalUpdate = false);
             }
         });
+    }
+
+    /// <summary>
+    /// Keeps what the device copied. Android has no clipboard history to ask for, so unless an item
+    /// is recorded here as it arrives, the previous one is gone for good.
+    /// </summary>
+    private async Task RecordHistoryAsync(object content, PairedDevice sourceDevice)
+    {
+        try
+        {
+            switch (content)
+            {
+                case string text when !string.IsNullOrWhiteSpace(text):
+                    await clipboardRepository.SaveAsync(sourceDevice.Id, "text/plain", text, isImage: false);
+                    break;
+
+                case StorageFile file when SupportedImageFileTypes.ContainsKey(file.FileType.TrimStart('.').ToLowerInvariant()):
+                    // The incoming copy sits in the temporary folder, which is pruned after a day
+                    var kept = LocalAppPaths.CreateClipboardHistoryFilePath(file.FileType);
+                    File.Copy(file.Path, kept, overwrite: true);
+                    await clipboardRepository.SaveAsync(sourceDevice.Id, file.ContentType, kept, isImage: true);
+                    break;
+
+                default:
+                    return;
+            }
+
+            HistoryChanged?.Invoke(this, sourceDevice);
+        }
+        catch (Exception ex)
+        {
+            logger.Warn($"Failed to record clipboard history: {ex.Message}", ex);
+        }
     }
 
     private static async Task<StorageFile?> CreateClipboardImageFileAsync(string base64Content, string mimeType)

--- a/src/Sefirah/Helpers/AppLanguageHelper.cs
+++ b/src/Sefirah/Helpers/AppLanguageHelper.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Sefirah.Data.Items;
 using Windows.Globalization;
+using Windows.System.UserProfile;
 
 namespace Sefirah.Helpers;
 
@@ -63,16 +64,50 @@ public static class AppLanguageHelper
 		var index = appLanguages.IndexOf(appLanguages.FirstOrDefault(dl => dl.Name == current.Name) ?? appLanguages.First());
 
 		// Set the system default language as the first item in the Languages collection
-		var systemLanguage = new AppLanguageItem(CultureInfo.InstalledUICulture.Name, systemDefault: true);
-		if (appLanguages.Select(lang => lang.Name.Contains(systemLanguage.Name)).Any())
-			appLanguages[0] = systemLanguage;
-		else
-			appLanguages[0] = new("en-US", systemDefault: true);
+		var systemCulture = GetSystemCulture();
+		appLanguages[0] = IsSupported(appLanguages, systemCulture)
+			? new AppLanguageItem(systemCulture.Name, systemDefault: true)
+			: new AppLanguageItem("en-US", systemDefault: true);
 
 		// Initialize the list
 		SupportedLanguages = new(appLanguages);
 		PreferredLanguage = SupportedLanguages[index];
 	}
+
+	/// <summary>
+	/// Gets the culture the app falls back to when no language override is set.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="GlobalizationPreferences"/> reports the display language the user picked in Windows.
+	/// <see cref="CultureInfo.InstalledUICulture"/> is wrong here because it reports en-US inside a
+	/// packaged app, and <see cref="CultureInfo.CurrentUICulture"/> follows this app's own override.
+	/// </remarks>
+	private static CultureInfo GetSystemCulture()
+	{
+		var preferred = GlobalizationPreferences.Languages.FirstOrDefault();
+		if (string.IsNullOrEmpty(preferred))
+			return CultureInfo.CurrentUICulture;
+
+		try
+		{
+			return new CultureInfo(preferred);
+		}
+		catch (CultureNotFoundException)
+		{
+			return CultureInfo.CurrentUICulture;
+		}
+	}
+
+	/// <summary>
+	/// Determines whether the app ships resources for the given culture.
+	/// </summary>
+	/// <remarks>
+	/// Manifest languages can be neutral, e.g. "cs" covers "cs-CZ", so both forms are matched.
+	/// </remarks>
+	private static bool IsSupported(IEnumerable<AppLanguageItem> languages, CultureInfo culture)
+		=> languages.Any(language =>
+			language.Code.Equals(culture.Name, StringComparison.OrdinalIgnoreCase) ||
+			language.Code.Equals(culture.TwoLetterISOLanguageName, StringComparison.OrdinalIgnoreCase));
 
 	/// <summary>
 	/// Attempts to change the preferred language code by index.

--- a/src/Sefirah/Helpers/AppLifecycleHelper.cs
+++ b/src/Sefirah/Helpers/AppLifecycleHelper.cs
@@ -113,6 +113,7 @@ public static class AppLifecycleHelper
                 .AddSingleton<SmsRepository>()
                 .AddSingleton<CallLogRepository>()
                 .AddSingleton<NotificationRepository>()
+                .AddSingleton<ClipboardRepository>()
 
                 // Platform-specific services
                 .AddPlatformServices()
@@ -143,6 +144,9 @@ public static class AppLifecycleHelper
                 .AddSingleton<MainPageViewModel>()
                 .AddSingleton<DevicesViewModel>()
                 .AddSingleton<AppsViewModel>()
+                .AddSingleton<FilesViewModel>()
+                .AddSingleton<PhotosViewModel>()
+                .AddSingleton<ClipboardViewModel>()
                 .AddSingleton<MessagesViewModel>()
                 .AddSingleton<CallsPageViewModel>()
                 )

--- a/src/Sefirah/Helpers/NetworkHelper.cs
+++ b/src/Sefirah/Helpers/NetworkHelper.cs
@@ -6,6 +6,17 @@ namespace Sefirah.Helpers;
 
 public static class NetworkHelper
 {
+    /// <summary>
+    /// 169.254.0.0/16 is what Windows hands to an adapter whose DHCP failed. Announcing those, or
+    /// putting them in the pairing QR, only makes the other device work through timeouts before it
+    /// reaches the address that actually routes.
+    /// </summary>
+    private static bool IsLinkLocal(IPAddress address)
+    {
+        var octets = address.GetAddressBytes();
+        return octets[0] == 169 && octets[1] == 254;
+    }
+
     public static List<IPAddressInfo> GetAllValidAddresses()
     {
         var addresses = new List<IPAddressInfo>();
@@ -19,8 +30,9 @@ public static class NetworkHelper
 
                 foreach (UnicastIPAddressInformation ip in ni.GetIPProperties().UnicastAddresses)
                 {
-                    if (ip.Address.AddressFamily is AddressFamily.InterNetwork && 
-                        !IPAddress.IsLoopback(ip.Address))
+                    if (ip.Address.AddressFamily is AddressFamily.InterNetwork &&
+                        !IPAddress.IsLoopback(ip.Address) &&
+                        !IsLinkLocal(ip.Address))
                     {
                         addresses.Add(new IPAddressInfo(
                             Address: ip.Address,

--- a/src/Sefirah/Platforms/Desktop/Features/SftpFeature.cs
+++ b/src/Sefirah/Platforms/Desktop/Features/SftpFeature.cs
@@ -31,6 +31,7 @@ public class SftpFeature(
         logger.Info($"Mounting SFTP for {device.Name}, IP: {device.Address}, Port: {info.Port}, Username: {info.Username}");
 
         _sessions[device.Id] = new DeviceSession(device.Address, info);
+        SessionChanged?.Invoke(this, device);
 
         var preferSshfs = ShouldPreferSshfs();
         if (preferSshfs)
@@ -107,6 +108,13 @@ public class SftpFeature(
             logger.Error($"Failed to browse device {device.Name} via SFTP URI", ex);
         }
     }
+
+    public event EventHandler<PairedDevice>? SessionChanged;
+
+    public SftpSession? GetSession(string deviceId)
+        => _sessions.TryGetValue(deviceId, out var session)
+            ? new SftpSession(session.Host, session.Info.Port, session.Info.Username, session.Info.Password, session.Info.Paths, session.Info.PathNames)
+            : null;
 
     public Task RemoveAll()
     {

--- a/src/Sefirah/Platforms/Windows/Features/SftpFeature.cs
+++ b/src/Sefirah/Platforms/Windows/Features/SftpFeature.cs
@@ -52,6 +52,7 @@ public class SftpFeature(
         if (string.IsNullOrEmpty(device.Address)) return;
 
         _sessions[device.Id] = (device.Address, info);
+        SessionChanged?.Invoke(this, device);
 
         if (!device.DeviceSettings.StorageAccess) return;
         if (!StorageProviderSyncRootManager.IsSupported()) return;
@@ -170,6 +171,13 @@ public class SftpFeature(
             });
         }
     }
+
+    public event EventHandler<PairedDevice>? SessionChanged;
+
+    public SftpSession? GetSession(string deviceId)
+        => _sessions.TryGetValue(deviceId, out var session)
+            ? new SftpSession(session.Host, session.Info.Port, session.Info.Username, session.Info.Password, session.Info.Paths, session.Info.PathNames)
+            : null;
 
     public async Task RemoveAll()
     {

--- a/src/Sefirah/Services/AdbService.cs
+++ b/src/Sefirah/Services/AdbService.cs
@@ -30,6 +30,9 @@ public class AdbService(
     private const string SefirahAndroidPackageId = "com.castle.sefirah";
     private const string WorkerNiceName = "sefirah_worker";
 
+    // adbd needs a moment to restart and start listening on 5555 after a tcpip switch
+    private static readonly TimeSpan TcpipSettleDelay = TimeSpan.FromSeconds(2);
+
     public AdbClient AdbClient => adbClient;
 
     public List<ScrcpyPreferenceItem> DisplayOrientationOptions { get; } =
@@ -705,29 +708,19 @@ public class AdbService(
                 return true;
             }
 
+            // The device is not listening on 5555, so we need an authorized session to switch it back
+            // to TCP/IP mode. A USB cable gives us one, otherwise fall back to the endpoints the device
+            // advertises over mDNS, which is how it comes back after a reboot without being plugged in.
             var usbDevice = AdbDevices.FirstOrDefault(d => d.Type is DeviceType.USB && d.IsOnline && d.Model == model);
-            if (usbDevice is null) return false;
-            
-            // If connection failed, try to enable TCP/IP mode using ADB if USB is connected
-            var tcpipEnabled = await EnableTcpipMode(usbDevice.Serial);
-            if (!tcpipEnabled)
+            if (usbDevice is not null)
             {
-                logger.Error("Failed to enable TCP/IP mode");
-                return false;
+                if (await EnableTcpipMode(usbDevice.Serial) && await RetryWirelessConnection(host))
+                    return true;
+
+                logger.Warn($"Could not switch {host} to TCP/IP mode over USB device {usbDevice.Serial}");
             }
 
-            await Task.Delay(200);
-
-            // Retry the connection after enabling TCP/IP mode
-            result = await ConnectWireless(host);
-            if (result)
-            {
-                logger.Info($"Successfully connected to {host} after enabling TCP/IP mode");
-                return true;
-            }
-
-            logger.Error("TCP/IP connection still failed after enabling TCP/IP mode");
-            return false;
+            return await TryConnectOverMdns(host);
         }
         catch (Exception ex)
         {
@@ -737,26 +730,129 @@ public class AdbService(
     }
 
     /// <summary>
-    /// Enables TCP/IP mode by restarting ADB with tcpip 5555 command
+    /// Gives the device time to restart adbd on port 5555 and retries the wireless connection.
+    /// </summary>
+    private async Task<bool> RetryWirelessConnection(string host)
+    {
+        await Task.Delay(TcpipSettleDelay);
+        var result = await ConnectWireless(host);
+        if (result)
+        {
+            logger.Info($"Successfully connected to {host} after enabling TCP/IP mode");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Falls back to the endpoints the device advertises over mDNS. A device that has been paired before
+    /// re-announces itself as <c>_adb-tls-connect._tcp</c> on a random port after every reboot, so connecting
+    /// there gives us the authorized session needed to switch it back to port 5555.
+    /// </summary>
+    private async Task<bool> TryConnectOverMdns(string host)
+    {
+        var services = await GetMdnsServicesAsync();
+
+        var candidates = services
+            // host:5555 has already been tried by the caller
+            .Where(s => !s.Endpoint.Equals($"{host}:5555", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(s => s.Endpoint.StartsWith($"{host}:", StringComparison.OrdinalIgnoreCase))
+            .ThenByDescending(s => s.Service.Contains("tls-connect", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (candidates.Count is 0)
+        {
+            logger.Warn($"No mDNS adb service found for {host}, the device has to be authorized manually");
+            return false;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            logger.Info($"Trying mDNS endpoint {candidate.Endpoint} ({candidate.Service}) for {host}");
+            if (!await ConnectWireless(candidate.Host, candidate.Port)) continue;
+
+            if (!await EnableTcpipMode(candidate.Endpoint))
+            {
+                logger.Warn($"Failed to enable TCP/IP mode through {candidate.Endpoint}");
+                continue;
+            }
+
+            if (await RetryWirelessConnection(host)) return true;
+        }
+
+        logger.Error($"TCP/IP connection to {host} still failed after trying {candidates.Count} mDNS endpoint(s)");
+        return false;
+    }
+
+    /// <summary>
+    /// Runs <c>adb mdns services</c> and returns the adb endpoints currently advertised on the network.
+    /// </summary>
+    private async Task<List<MdnsService>> GetMdnsServicesAsync()
+    {
+        var result = await RunAdbCommandAsync("mdns services");
+        if (result is not { ExitCode: 0 }) return [];
+
+        List<MdnsService> services = [];
+        foreach (var line in result.Value.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            // "<instance>\t<service>\t<ip>:<port>". The header line carries no tabs and is skipped here.
+            var columns = line.Split('\t', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (columns.Length < 3) continue;
+
+            var separator = columns[2].LastIndexOf(':');
+            if (separator <= 0 || !int.TryParse(columns[2][(separator + 1)..], out var port)) continue;
+
+            services.Add(new MdnsService(columns[0], columns[1], columns[2][..separator], port));
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// An adb endpoint advertised over mDNS, as reported by <c>adb mdns services</c>.
+    /// </summary>
+    private readonly record struct MdnsService(string Instance, string Service, string Host, int Port)
+    {
+        public string Endpoint => $"{Host}:{Port}";
+    }
+
+    /// <summary>
+    /// Enables TCP/IP mode by running <c>adb -s &lt;serial&gt; tcpip 5555</c> on a device we can already reach.
     /// </summary>
     private async Task<bool> EnableTcpipMode(string serialId)
     {
+        logger.Info($"Enabling TCP/IP mode on {serialId}");
+        var result = await RunAdbCommandAsync($"-s {serialId} tcpip 5555");
+        if (result is null) return false;
+
+        if (!string.IsNullOrWhiteSpace(result.Value.Error))
+        {
+            logger.Warn($"ADB tcpip command error: {result.Value.Error}");
+        }
+
+        // Restart our ADB client to pick up the changes
+        await RestartAdbClient();
+
+        return result.Value.ExitCode == 0;
+    }
+
+    /// <summary>
+    /// Runs the configured adb executable and captures its output.
+    /// </summary>
+    private async Task<(int ExitCode, string Output, string Error)?> RunAdbCommandAsync(string arguments)
+    {
+        var adbPath = userSettingsService.GeneralSettingsService.AdbPath;
+        if (string.IsNullOrEmpty(adbPath))
+        {
+            logger.Error("ADB path not configured");
+            return null;
+        }
+
         try
         {
-            string adbPath = userSettingsService.GeneralSettingsService.AdbPath;
-            if (string.IsNullOrEmpty(adbPath))
-            {
-                logger.Error("ADB path not configured");
-                return false;
-            }
-
-            logger.Info($"Enabling TCP/IP mode using ADB at: {adbPath}");
-            
-            // Runs "adb -s <serial> tcpip 5555" to enable TCP/IP mode on the specified device
             var processInfo = new ProcessStartInfo
             {
                 FileName = adbPath,
-                Arguments = $"-s {serialId} tcpip 5555",
+                Arguments = arguments,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -767,27 +863,20 @@ public class AdbService(
             if (process is null)
             {
                 logger.Error("Failed to start ADB process");
-                return false;
+                return null;
             }
 
+            // Drain both pipes before waiting, a full buffer would otherwise deadlock the process
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
             await process.WaitForExitAsync();
-            var output = await process.StandardOutput.ReadToEndAsync();
-            var error = await process.StandardError.ReadToEndAsync();
-            
-            if (!string.IsNullOrEmpty(error))
-            {
-                logger.Warn($"ADB tcpip command error: {error}");
-            }
 
-            // Restart our ADB client to pick up the changes
-            await RestartAdbClient();
-            
-            return process.ExitCode == 0;
+            return (process.ExitCode, await outputTask, await errorTask);
         }
         catch (Exception ex)
         {
-            logger.Error($"Failed to enable TCP/IP mode: {ex.Message}", ex);
-            return false;
+            logger.Error($"Failed to run adb {arguments}: {ex.Message}", ex);
+            return null;
         }
     }
 

--- a/src/Sefirah/Services/AdbService.cs
+++ b/src/Sefirah/Services/AdbService.cs
@@ -30,6 +30,9 @@ public class AdbService(
     private const string SefirahAndroidPackageId = "com.castle.sefirah";
     private const string WorkerNiceName = "sefirah_worker";
 
+    private const string DeviceIdCommand =
+        $"cat /storage/emulated/0/Android/data/{SefirahAndroidPackageId}/files/device_info.txt";
+
     // adbd needs a moment to restart and start listening on 5555 after a tcpip switch
     private static readonly TimeSpan TcpipSettleDelay = TimeSpan.FromSeconds(2);
 
@@ -950,13 +953,49 @@ public class AdbService(
         }
     }
 
+    /// <summary>
+    /// The device id is read from a file the app writes on its first run, because the desktop cannot
+    /// see the app's own ANDROID_ID over adb. A device that showed up before the app wrote that file
+    /// keeps an unusable id, so ask the device again rather than giving up on the match.
+    /// </summary>
+    private async Task<AdbDevice?> ResolveAdbDeviceAsync(PairedDevice device)
+    {
+        if (device.ConnectedAdbDevices.FirstOrDefault() is { } known) return known;
+
+        foreach (var candidate in AdbDevices.Where(d => d.IsOnline && d.DeviceData is not null).ToList())
+        {
+            try
+            {
+                var id = (await ShellAsync(candidate, DeviceIdCommand)).Trim();
+                if (string.IsNullOrEmpty(id) || id != device.Id) continue;
+
+                logger.Info($"Re-resolved adb device {candidate.Serial} as {device.Name}");
+                candidate.AndroidId = id;
+                return candidate;
+            }
+            catch (Exception ex)
+            {
+                logger.Debug($"Could not read the device id from {candidate.Serial}: {ex.Message}");
+            }
+        }
+
+        return null;
+    }
+
     /// <summary>Starts the worker via adb shell if it isn't already running.</summary>
     public async Task TryStartWorkerAsync(PairedDevice device, string command)
     {
-        if (device.ConnectedAdbDevices.FirstOrDefault() is not { } adbDevice)
+        if (await ResolveAdbDeviceAsync(device) is not { } adbDevice)
+        {
+            logger.Warn($"No adb device matches {device.Name}, the worker cannot be started over adb");
             return;
+        }
 
-        if (adbDevice.DeviceData is null || adbDevice.State is not DeviceState.Online) return;
+        if (adbDevice.DeviceData is null || adbDevice.State is not DeviceState.Online)
+        {
+            logger.Warn($"Adb device {adbDevice.Serial} is not online, the worker cannot be started");
+            return;
+        }
 
         try
         {

--- a/src/Sefirah/Services/NetworkService.cs
+++ b/src/Sefirah/Services/NetworkService.cs
@@ -180,7 +180,20 @@ public class NetworkService(
 
             logger.Debug($"Processing message: {(messageString.Length > 100 ? string.Concat(messageString.AsSpan(0, 100), "...") : messageString)}");
 
-            var socketMessage = JsonMessageSerializer.DeserializeMessage(messageString);
+            SocketMessage? socketMessage;
+            try
+            {
+                socketMessage = JsonMessageSerializer.DeserializeMessage(messageString);
+            }
+            catch (JsonException ex)
+            {
+                // A peer running a different version can send message types this build does not know.
+                // Skipping the single message keeps the rest of the batch usable, whereas letting the
+                // exception escape discards every message parsed so far along with the remaining ones.
+                logger.Warn($"Skipping unrecognized message: {ex.Message}");
+                continue;
+            }
+
             if (socketMessage is not null)
             {
                 messages.Add(socketMessage);

--- a/src/Sefirah/Services/NetworkService.cs
+++ b/src/Sefirah/Services/NetworkService.cs
@@ -25,6 +25,8 @@ public class NetworkService(
 
     private static readonly IEnumerable<int> PORT_RANGE = Enumerable.Range(5150, 20); // 5150 to 5169
 
+    private static readonly TimeSpan ReconnectInterval = TimeSpan.FromSeconds(30);
+
     private readonly ConcurrentDictionary<Guid, StringBuilder> connectionBuffers = [];
     private readonly ConcurrentDictionary<Guid, DeviceAuth> deviceAuths = [];
     private readonly HashSet<string> connectingDeviceIds = [];
@@ -66,6 +68,7 @@ public class NetworkService(
                     ServerPort = port;
                     isRunning = true;
                     logger.Info($"Server started on port: {port}");
+                    StartReconnectLoop();
                     return;
                 }
                 server.Dispose();
@@ -641,6 +644,41 @@ public class NetworkService(
                 connectingDeviceIds.Remove(deviceId);
             }
         }
+    }
+
+    /// <summary>
+    /// Discovery runs on UDP broadcast and mDNS, and neither crosses a VPN tunnel. With no announcement
+    /// arriving, nothing would ever trigger a reconnect, so paired devices that have a known address
+    /// are retried on a timer instead of waiting to be found.
+    /// </summary>
+    private void StartReconnectLoop()
+    {
+        _ = Task.Run(async () =>
+        {
+            using var timer = new PeriodicTimer(ReconnectInterval);
+            while (await timer.WaitForNextTickAsync())
+            {
+                try
+                {
+                    // PairedDevices is bound to the UI, so it is only safe to walk on its own thread
+                    await App.MainWindow.DispatcherQueue.EnqueueAsync(() =>
+                    {
+                        foreach (var device in PairedDevices)
+                        {
+                            if (device.IsConnectedOrConnecting) continue;
+                            if (device.GetEnabledAddresses().Count == 0) continue;
+
+                            logger.Debug($"Retrying {device.Name} on its known addresses");
+                            Connect(device);
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    logger.Warn($"Reconnect sweep failed: {ex.Message}", ex);
+                }
+            }
+        });
     }
 
     public void Connect(PairedDevice device)

--- a/src/Sefirah/Strings/en-US/Resources.resw
+++ b/src/Sefirah/Strings/en-US/Resources.resw
@@ -358,6 +358,117 @@ page.</value>
   <data name="Apps" xml:space="preserve">
     <value>Apps</value>
   </data>
+  <data name="ConnectManually" xml:space="preserve">
+    <value>Connect by address</value>
+  </data>
+  <data name="ConnectManuallyDescription" xml:space="preserve">
+    <value>Type the address shown on the other device. Use this when discovery cannot reach it, for instance over a VPN.</value>
+  </data>
+  <data name="ThisDeviceAddress" xml:space="preserve">
+    <value>This PC is reachable at {0}. Type the other device's address to pair without discovery.</value>
+  </data>
+  <data name="InvalidAddress" xml:space="preserve">
+    <value>That is not a valid address</value>
+  </data>
+  <data name="ConnectingToAddress" xml:space="preserve">
+    <value>Connecting to {0} on port {1}…</value>
+  </data>
+  <data name="Files" xml:space="preserve">
+    <value>Files</value>
+  </data>
+  <data name="Photos" xml:space="preserve">
+    <value>Photos</value>
+  </data>
+  <data name="ClipboardHistory" xml:space="preserve">
+    <value>Clipboard</value>
+  </data>
+  <data name="ClipboardHistorySubtitle" xml:space="preserve">
+    <value>What the device has copied since Sefirah started keeping track. Click an item to put it back on the Windows clipboard.</value>
+  </data>
+  <data name="ClipboardCopy" xml:space="preserve">
+    <value>Copy to clipboard</value>
+  </data>
+  <data name="ClipboardEmpty" xml:space="preserve">
+    <value>Nothing here yet. Copy something on the device and it shows up.</value>
+  </data>
+  <data name="ClipboardNoDevice" xml:space="preserve">
+    <value>Connect a device to see what it copies</value>
+  </data>
+  <data name="ClipboardImageMissing" xml:space="preserve">
+    <value>The stored image is gone</value>
+  </data>
+  <data name="ClipboardClearTitle" xml:space="preserve">
+    <value>Clear history</value>
+  </data>
+  <data name="ClipboardClearSubtitle" xml:space="preserve">
+    <value>Remove every stored clipboard item for this device? This cannot be undone.</value>
+  </data>
+  <data name="PhotosRecent" xml:space="preserve">
+    <value>Recent pictures on the device</value>
+  </data>
+  <data name="PhotosOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="PhotosCopy" xml:space="preserve">
+    <value>Copy to clipboard</value>
+  </data>
+  <data name="PhotosSave" xml:space="preserve">
+    <value>Save to PC</value>
+  </data>
+  <data name="PhotosEmpty" xml:space="preserve">
+    <value>No pictures found on the device</value>
+  </data>
+  <data name="PhotosUnavailable" xml:space="preserve">
+    <value>Connect a device and turn on Storage access for it in the Android app to see its pictures</value>
+  </data>
+  <data name="PhotosDisconnected" xml:space="preserve">
+    <value>Can't reach the device. Pictures come back on their own when it returns.</value>
+  </data>
+  <data name="PhotosDeleteTitle" xml:space="preserve">
+    <value>Delete picture</value>
+  </data>
+  <data name="PhotosDeleteSubtitle" xml:space="preserve">
+    <value>Delete '{0}' from the device? It goes to the device recycle bin.</value>
+  </data>
+  <data name="FilesOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="FilesDownload" xml:space="preserve">
+    <value>Save to PC</value>
+  </data>
+  <data name="FilesRename" xml:space="preserve">
+    <value>Rename</value>
+  </data>
+  <data name="FilesUpload" xml:space="preserve">
+    <value>Send a file to this folder</value>
+  </data>
+  <data name="FilesNewFolder" xml:space="preserve">
+    <value>New folder</value>
+  </data>
+  <data name="FilesRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="FilesGoUp" xml:space="preserve">
+    <value>Up one folder</value>
+  </data>
+  <data name="FilesCreate" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="FilesDisconnected" xml:space="preserve">
+    <value>Can't reach the device. It may have left the network; this page reconnects on its own when it comes back.</value>
+  </data>
+  <data name="FilesEmptyFolder" xml:space="preserve">
+    <value>This folder is empty</value>
+  </data>
+  <data name="FilesUnavailable" xml:space="preserve">
+    <value>Connect a device and turn on Storage access for it in the Android app to browse its files</value>
+  </data>
+  <data name="FilesDeleteTitle" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="FilesDeleteSubtitle" xml:space="preserve">
+    <value>Are you sure you want to delete '{0}' from the device? This action cannot be undone.</value>
+  </data>
   <data name="NewMessage" xml:space="preserve">
     <value>New message</value>
   </data>

--- a/src/Sefirah/Strings/it-IT/Resources.resw
+++ b/src/Sefirah/Strings/it-IT/Resources.resw
@@ -1,0 +1,1091 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="About" xml:space="preserve">
+    <value>Informazioni</value>
+  </data>
+  <data name="General" xml:space="preserve">
+    <value>Generale</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
+  <data name="PrivacyPolicy" xml:space="preserve">
+    <value>Informativa sulla privacy</value>
+  </data>
+  <data name="SupportDevelopment" xml:space="preserve">
+    <value>Sostieni lo sviluppo</value>
+  </data>
+  <data name="OpenLogs" xml:space="preserve">
+    <value>Apri i log</value>
+  </data>
+  <data name="GitHubRepository" xml:space="preserve">
+    <value>Repository GitHub</value>
+  </data>
+  <data name="AndroidGitHubRepository" xml:space="preserve">
+    <value>Repository GitHub Android</value>
+  </data>
+  <data name="Feedback" xml:space="preserve">
+    <value>Feedback</value>
+  </data>
+  <data name="Notifications" xml:space="preserve">
+    <value>Notifiche</value>
+  </data>
+  <data name="ThirdPartyLibraries" xml:space="preserve">
+    <value>Librerie di terze parti</value>
+  </data>
+  <data name="SaveLocation" xml:space="preserve">
+    <value>Percorso di salvataggio</value>
+  </data>
+  <data name="RemoteStorageLocation" xml:space="preserve">
+    <value>Percorso di archiviazione remota</value>
+  </data>
+  <data name="StorageMount" xml:space="preserve">
+    <value>Montaggio archiviazione</value>
+  </data>
+  <data name="StorageMountDescription" xml:space="preserve">
+    <value>Come viene montata l'archiviazione del dispositivo nel file manager. Auto sceglie GVfs su GNOME e sshfs su KDE. La modifica viene applicata alla connessione successiva.</value>
+  </data>
+  <data name="GVfs" xml:space="preserve">
+    <value>GVfs</value>
+  </data>
+  <data name="Sshfs" xml:space="preserve">
+    <value>sshfs</value>
+  </data>
+  <data name="ShowClipboardToast" xml:space="preserve">
+    <value>Mostra notifica popup per gli appunti</value>
+  </data>
+  <data name="ClipboardFiles" xml:space="preserve">
+    <value>Aggiungi i file ricevuti agli appunti</value>
+  </data>
+  <data name="GeneralSettings" xml:space="preserve">
+    <value>Impostazioni generali</value>
+  </data>
+  <data name="ShowNotificationToast" xml:space="preserve">
+    <value>Mostra notifiche popup</value>
+  </data>
+  <data name="IgnoreWindowsApps" xml:space="preserve">
+    <value>Ignora le notifiche remote delle app Windows attive</value>
+  </data>
+  <data name="NotificationFilterDisabled.Content" xml:space="preserve">
+    <value>Disattivate</value>
+  </data>
+  <data name="NotificationFilterFeed.Content" xml:space="preserve">
+    <value>Feed delle notifiche</value>
+  </data>
+  <data name="NotificationFilterToastFeed.Content" xml:space="preserve">
+    <value>Feed delle notifiche + popup</value>
+  </data>
+  <data name="AvailableDevices.Title" xml:space="preserve">
+    <value>Dispositivi disponibili</value>
+  </data>
+  <data name="AvailableDevices.Subtitle" xml:space="preserve">
+    <value>I dispositivi Android che eseguono l'app nella stessa rete verranno mostrati qui sotto</value>
+  </data>
+  <data name="StartupOption" xml:space="preserve">
+    <value>Opzione di avvio</value>
+  </data>
+  <data name="StartupOptionDescription" xml:space="preserve">
+    <value>Scegli come avviare l'app all'accensione di Windows</value>
+  </data>
+  <data name="StartupOptionMinimized.Content" xml:space="preserve">
+    <value>Avvia ridotta a icona</value>
+  </data>
+  <data name="StartupOptionMaximized.Content" xml:space="preserve">
+    <value>Avvia ingrandita</value>
+  </data>
+  <data name="StartupOptionSystemTray.Content" xml:space="preserve">
+    <value>Avvia nell'area di notifica</value>
+  </data>
+  <data name="StartupOptionDisabled.Content" xml:space="preserve">
+    <value>Disattivata</value>
+  </data>
+  <data name="Theme" xml:space="preserve">
+    <value>Tema</value>
+  </data>
+  <data name="ThemeDescription" xml:space="preserve">
+    <value>Scegli il tema predefinito dell'app</value>
+  </data>
+  <data name="BackdropMaterial" xml:space="preserve">
+    <value>Materiale di sfondo</value>
+  </data>
+  <data name="BackdropMaterialMica" xml:space="preserve">
+    <value>Mica</value>
+  </data>
+  <data name="BackdropMaterialAcrylic" xml:space="preserve">
+    <value>Acrilico</value>
+  </data>
+  <data name="Default" xml:space="preserve">
+    <value>Predefinito</value>
+  </data>
+  <data name="ThemeLight.Content" xml:space="preserve">
+    <value>Chiaro</value>
+  </data>
+  <data name="ThemeDark.Content" xml:space="preserve">
+    <value>Scuro</value>
+  </data>
+  <data name="RemoveDeviceDialogTitle" xml:space="preserve">
+    <value>Rimuovi dispositivo</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Rimuovi</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="OnboardingWelcome.Title" xml:space="preserve">
+    <value>Benvenuto in Sefirah</value>
+  </data>
+  <data name="OnboardingWelcome.Subtitle" xml:space="preserve">
+    <value>Per iniziare, scarica e installa l'app companion dalla relativa pagina
+GitHub.</value>
+  </data>
+  <data name="OnboardingWelcomeGetStarted" xml:space="preserve">
+    <value>Inizia</value>
+  </data>
+  <data name="OnboardingSkip" xml:space="preserve">
+    <value>Salta per ora</value>
+  </data>
+  <data name="OnboardingDevice.Title" xml:space="preserve">
+    <value>Connetti il tuo dispositivo</value>
+  </data>
+  <data name="OnboardingDevice.Subtitle" xml:space="preserve">
+    <value>Scansiona il codice QR o esegui l'associazione direttamente dai dispositivi rilevati qui sotto</value>
+  </data>
+  <data name="ConnectionRequest.Title" xml:space="preserve">
+    <value>Richiesta di connessione del dispositivo</value>
+  </data>
+  <data name="ConnectionRequest.Subtitle" xml:space="preserve">
+    <value>Verifica che il codice corrisponda su entrambi i dispositivi:</value>
+  </data>
+  <data name="ConnectionRequestRejectButton" xml:space="preserve">
+    <value>Rifiuta</value>
+  </data>
+  <data name="NotificationsClearButton" xml:space="preserve">
+    <value>Cancella tutto</value>
+  </data>
+  <data name="ConnectionRequestAcceptButton" xml:space="preserve">
+    <value>Accetta</value>
+  </data>
+  <data name="NoDevicesFound" xml:space="preserve">
+    <value>Nessun dispositivo trovato</value>
+  </data>
+  <data name="OpenLinksInBrowser" xml:space="preserve">
+    <value>Apri i link nel browser</value>
+  </data>
+  <data name="Connected.Text" xml:space="preserve">
+    <value>Connesso</value>
+  </data>
+  <data name="Disconnected.Text" xml:space="preserve">
+    <value>Disconnesso</value>
+  </data>
+  <data name="ShowHideWindow" xml:space="preserve">
+    <value>Mostra/Nascondi finestra</value>
+  </data>
+  <data name="Exit" xml:space="preserve">
+    <value>Esci</value>
+  </data>
+  <data name="SelectLocation" xml:space="preserve">
+    <value>Seleziona percorso</value>
+  </data>
+  <data name="RemoveDeviceDialogSubtitle" xml:space="preserve">
+    <value>Vuoi davvero rimuovere '{0}'? L'azione non può essere annullata.</value>
+  </data>
+  <data name="AppSpecificSettings" xml:space="preserve">
+    <value>Impostazioni per app</value>
+  </data>
+  <data name="SendButton" xml:space="preserve">
+    <value>Invia</value>
+  </data>
+  <data name="ReplyPlaceholder" xml:space="preserve">
+    <value>Scrivi una risposta</value>
+  </data>
+  <data name="FileTransferNotificationAction.OpenFile" xml:space="preserve">
+    <value>Apri file</value>
+  </data>
+  <data name="FileTransferNotificationAction.OpenFolder" xml:space="preserve">
+    <value>Apri cartella</value>
+  </data>
+  <data name="NotificationFilterButton" xml:space="preserve">
+    <value>Disattiva le notifiche di {0}</value>
+  </data>
+  <data name="SubmitBugReport" xml:space="preserve">
+    <value>Segnala un bug</value>
+  </data>
+  <data name="SubmitFeatureRequest" xml:space="preserve">
+    <value>Richiesta di funzionalità</value>
+  </data>
+  <data name="IgnoreNotificationDuringDnd" xml:space="preserve">
+    <value>Non mostrare le notifiche popup quando il telefono è in Non disturbare</value>
+  </data>
+  <data name="Devices.Title" xml:space="preserve">
+    <value>Dispositivi</value>
+  </data>
+  <data name="Pin" xml:space="preserve">
+    <value>Fissa</value>
+  </data>
+  <data name="Unpin" xml:space="preserve">
+    <value>Rimuovi</value>
+  </data>
+  <data name="VideoSettings" xml:space="preserve">
+    <value>Impostazioni video</value>
+  </data>
+  <data name="AudioSettings" xml:space="preserve">
+    <value>Impostazioni audio</value>
+  </data>
+  <data name="OpenApp" xml:space="preserve">
+    <value>Apri nell'app</value>
+  </data>
+  <data name="ScreenOff" xml:space="preserve">
+    <value>Mantieni spento lo schermo del dispositivo durante il mirroring</value>
+  </data>
+  <data name="PhysicalKeyboard" xml:space="preserve">
+    <value>Disabilita la tastiera su schermo</value>
+  </data>
+  <data name="ScrcpyClipboardAutosync" xml:space="preserve">
+    <value>Sincronizzazione automatica degli appunti</value>
+  </data>
+  <data name="ScrcpyClipboardAutosyncDescription" xml:space="preserve">
+    <value>Se attivo, l'app aggiunge il flag `--no-clipboard-autosync`. Valuta di lasciarlo disattivato se usi la sincronizzazione degli appunti dell'app.</value>
+  </data>
+  <data name="Bitrate" xml:space="preserve">
+    <value>Bitrate</value>
+  </data>
+  <data name="Resolution" xml:space="preserve">
+    <value>Risoluzione</value>
+  </data>
+  <data name="Buffer" xml:space="preserve">
+    <value>Buffer</value>
+  </data>
+  <data name="Messages" xml:space="preserve">
+    <value>Messaggi</value>
+  </data>
+  <data name="EmptyMessages" xml:space="preserve">
+    <value>Inizia una nuova conversazione o selezionane una per rispondere</value>
+  </data>
+  <data name="MessagePlaceholder" xml:space="preserve">
+    <value>Scrivi un messaggio</value>
+  </data>
+  <data name="Apps" xml:space="preserve">
+    <value>App</value>
+  </data>
+  <data name="NewMessage" xml:space="preserve">
+    <value>Nuovo messaggio</value>
+  </data>
+  <data name="SearchMessages" xml:space="preserve">
+    <value>Cerca nei messaggi</value>
+  </data>
+  <data name="AddressInputPlaceholder" xml:space="preserve">
+    <value>A</value>
+  </data>
+  <data name="RemoveAddress" xml:space="preserve">
+    <value>Rimuovi indirizzo</value>
+  </data>
+  <data name="CopyMessage" xml:space="preserve">
+    <value>Copia messaggio</value>
+  </data>
+  <data name="NoApps" xml:space="preserve">
+    <value>Nessuna app trovata</value>
+  </data>
+  <data name="AdditionalArguments" xml:space="preserve">
+    <value>Argomenti aggiuntivi</value>
+  </data>
+  <data name="AdbDeviceOffline" xml:space="preserve">
+    <value>Il dispositivo ADB è offline</value>
+  </data>
+  <data name="AdbDeviceOfflineDescription" xml:space="preserve">
+    <value>Collega il dispositivo tramite USB con il debug USB attivo, quindi riprova.</value>
+  </data>
+  <data name="Dismiss" xml:space="preserve">
+    <value>Ignora</value>
+  </data>
+  <data name="ScrcpyNotFound" xml:space="preserve">
+    <value>Scrcpy non trovato</value>
+  </data>
+  <data name="ScrcpyNotFoundDescription" xml:space="preserve">
+    <value>Seleziona la cartella in cui si trova scrcpy</value>
+  </data>
+  <data name="SearchApps" xml:space="preserve">
+    <value>Cerca app</value>
+  </data>
+  <data name="DisableVideoForwarding" xml:space="preserve">
+    <value>Disabilita l'inoltro video</value>
+  </data>
+  <data name="VideoCodec" xml:space="preserve">
+    <value>Codec video</value>
+  </data>
+  <data name="FrameRate" xml:space="preserve">
+    <value>Frequenza fotogrammi</value>
+  </data>
+  <data name="Crop" xml:space="preserve">
+    <value>Ritaglio</value>
+  </data>
+  <data name="Display" xml:space="preserve">
+    <value>Schermo</value>
+  </data>
+  <data name="VirtualDisplaySize" xml:space="preserve">
+    <value>Dimensione dello schermo virtuale</value>
+  </data>
+  <data name="DisplayOrientation" xml:space="preserve">
+    <value>Orientamento dello schermo</value>
+  </data>
+  <data name="RotationAngle" xml:space="preserve">
+    <value>Angolo di rotazione</value>
+  </data>
+  <data name="AudioOutputMode" xml:space="preserve">
+    <value>Uscita audio</value>
+  </data>
+  <data name="ForwardMicrophone" xml:space="preserve">
+    <value>Inoltra il microfono</value>
+  </data>
+  <data name="AudioOutputBuffer" xml:space="preserve">
+    <value>Buffer di uscita audio</value>
+  </data>
+  <data name="AudioCodec" xml:space="preserve">
+    <value>Codec audio</value>
+  </data>
+  <data name="AdbSettings" xml:space="preserve">
+    <value>Impostazioni ADB</value>
+  </data>
+  <data name="AutoConnect" xml:space="preserve">
+    <value>Connessione automatica</value>
+  </data>
+  <data name="Both" xml:space="preserve">
+    <value>Entrambi</value>
+  </data>
+  <data name="DesktopDevice" xml:space="preserve">
+    <value>Dispositivo desktop</value>
+  </data>
+  <data name="RemoteDevice" xml:space="preserve">
+    <value>Dispositivo remoto</value>
+  </data>
+  <data name="SelectDevice" xml:space="preserve">
+    <value>Seleziona un dispositivo</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Avvia</value>
+  </data>
+  <data name="ScrcpyDevicePreference" xml:space="preserve">
+    <value>Preferenza dispositivo</value>
+  </data>
+  <data name="AskEverytime" xml:space="preserve">
+    <value>Chiedi ogni volta</value>
+  </data>
+  <data name="Auto" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="ScrcpyErrorTitle" xml:space="preserve">
+    <value>Avvio di scrcpy non riuscito</value>
+  </data>
+  <data name="CopyError" xml:space="preserve">
+    <value>Copia errore</value>
+  </data>
+  <data name="DeviceName" xml:space="preserve">
+    <value>Nome dispositivo</value>
+  </data>
+  <data name="EnableVirtualDisplay" xml:space="preserve">
+    <value>Abilita schermo virtuale</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Disinstalla</value>
+  </data>
+  <data name="UnlockDeviceHelpTitle" xml:space="preserve">
+    <value>Guida ai comandi di sblocco</value>
+  </data>
+  <data name="UnlockDeviceHelpDescription" xml:space="preserve">
+    <value>I comandi vengono eseguiti in ordine prima di avviare scrcpy. Imposta un ritardo in millisecondi dopo ogni comando se il dispositivo ha bisogno di tempo per reagire. Usa 0 per nessun ritardo. Usa %pwd% come segnaposto per farti richiedere la password.</value>
+  </data>
+  <data name="UnlockDeviceHelpExample" xml:space="preserve">
+    <value>Esempio:</value>
+  </data>
+  <data name="UnlockDeviceHelpExampleCommands" xml:space="preserve">
+    <value>input keyevent 224
+input text %pwd%
+input keyevent 66</value>
+  </data>
+  <data name="PinnedApps" xml:space="preserve">
+    <value>App fissate</value>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>Azioni</value>
+  </data>
+  <data name="ActionsDescription" xml:space="preserve">
+    <value>Configura azioni personalizzate e comandi eseguibili</value>
+  </data>
+  <data name="AdbNoDevice" xml:space="preserve">
+    <value>Nessun dispositivo ADB connesso</value>
+  </data>
+  <data name="AdbNoDeviceSubtitle" xml:space="preserve">
+    <value>Attiva ADB e collega il dispositivo tramite USB o Wi-Fi per vederlo qui.</value>
+  </data>
+  <data name="ClipboardSettings" xml:space="preserve">
+    <value>Impostazioni appunti</value>
+  </data>
+  <data name="DeviceSettings" xml:space="preserve">
+    <value>Impostazioni dispositivo</value>
+  </data>
+  <data name="NotificationSettings" xml:space="preserve">
+    <value>Impostazioni notifiche</value>
+  </data>
+  <data name="ScreenMirrorSettings" xml:space="preserve">
+    <value>Impostazioni mirroring dello schermo</value>
+  </data>
+  <data name="OpenLinksInBrowserDescription" xml:space="preserve">
+    <value>Apri automaticamente nel browser predefinito i link presenti negli appunti</value>
+  </data>
+  <data name="ShowClipboardToastDescription" xml:space="preserve">
+    <value>Mostra notifiche popup per le modifiche agli appunti</value>
+  </data>
+  <data name="ClipboardFilesDescription" xml:space="preserve">
+    <value>Abilita la sincronizzazione dei file tramite gli appunti</value>
+  </data>
+  <data name="AutoConnectDescription" xml:space="preserve">
+    <value>Connetti automaticamente ad ADB quando il dispositivo si connette</value>
+  </data>
+  <data name="SyncClipboardChanges" xml:space="preserve">
+    <value>Sincronizza le modifiche agli appunti con questo dispositivo</value>
+  </data>
+  <data name="ConfigureNotificationSettings" xml:space="preserve">
+    <value>Configura le impostazioni delle notifiche</value>
+  </data>
+  <data name="DisplayToastNotifications" xml:space="preserve">
+    <value>Mostra le notifiche popup su questo PC</value>
+  </data>
+  <data name="ShowBadge" xml:space="preserve">
+    <value>Mostra badge</value>
+  </data>
+  <data name="ShowBadgeDescription" xml:space="preserve">
+    <value>Mostra il badge delle notifiche sulla barra delle applicazioni</value>
+  </data>
+  <data name="LowBatteryAlerts" xml:space="preserve">
+    <value>Avvisi di batteria scarica</value>
+  </data>
+  <data name="LowBatteryAlertsDescription" xml:space="preserve">
+    <value>Mostra una notifica quando questo dispositivo raggiunge o scende sotto la percentuale di batteria selezionata</value>
+  </data>
+  <data name="LowBatteryThreshold" xml:space="preserve">
+    <value>Soglia di batteria scarica</value>
+  </data>
+  <data name="LowBatteryThresholdDescription" xml:space="preserve">
+    <value>Scegli la percentuale di batteria che attiva l'avviso per questo dispositivo</value>
+  </data>
+  <data name="IgnoreDuringDoNotDisturb" xml:space="preserve">
+    <value>Ignora durante Non disturbare</value>
+  </data>
+  <data name="IgnoreDuringDoNotDisturbDescription" xml:space="preserve">
+    <value>Non mostrare le notifiche quando Non disturbare è attivo</value>
+  </data>
+  <data name="ConnectionPreference" xml:space="preserve">
+    <value>Preferenza di connessione</value>
+  </data>
+  <data name="AddAction" xml:space="preserve">
+    <value>Aggiungi azione</value>
+  </data>
+  <data name="Reorder" xml:space="preserve">
+    <value>Trascina per riordinare</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>Esegui</value>
+  </data>
+  <data name="Power" xml:space="preserve">
+    <value>Alimentazione</value>
+  </data>
+  <data name="Sleep" xml:space="preserve">
+    <value>Sospensione</value>
+  </data>
+  <data name="Hibernate" xml:space="preserve">
+    <value>Ibernazione</value>
+  </data>
+  <data name="Restart" xml:space="preserve">
+    <value>Riavvia</value>
+  </data>
+  <data name="Shutdown" xml:space="preserve">
+    <value>Arresta</value>
+  </data>
+  <data name="Lock" xml:space="preserve">
+    <value>Blocca</value>
+  </data>
+  <data name="LogOff" xml:space="preserve">
+    <value>Disconnetti</value>
+  </data>
+  <data name="Link" xml:space="preserve">
+    <value>Link</value>
+  </data>
+  <data name="EnterLink" xml:space="preserve">
+    <value>https://example.com</value>
+  </data>
+  <data name="RunPath" xml:space="preserve">
+    <value>Percorso</value>
+  </data>
+  <data name="EnterRunPath" xml:space="preserve">
+    <value>Percorso di un file, una cartella o un'applicazione</value>
+  </data>
+  <data name="ActionIcon" xml:space="preserve">
+    <value>Icona</value>
+  </data>
+  <data name="BrowseCustomIcon" xml:space="preserve">
+    <value>Sfoglia immagine</value>
+  </data>
+  <data name="ChangeIcon" xml:space="preserve">
+    <value>Cambia…</value>
+  </data>
+  <data name="SearchIcons" xml:space="preserve">
+    <value>Cerca icone</value>
+  </data>
+  <data name="UseBuiltInIcon" xml:space="preserve">
+    <value>Usa integrata</value>
+  </data>
+  <data name="AskForConfirmation" xml:space="preserve">
+    <value>Chiedi conferma</value>
+  </data>
+  <data name="PowerKind" xml:space="preserve">
+    <value>Opzione di alimentazione</value>
+  </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Modifica</value>
+  </data>
+  <data name="NoActionsConfigured" xml:space="preserve">
+    <value>Nessuna azione configurata</value>
+  </data>
+  <data name="ActionName" xml:space="preserve">
+    <value>Nome azione</value>
+  </data>
+  <data name="ExecutablePath" xml:space="preserve">
+    <value>Percorso dell'eseguibile</value>
+  </data>
+  <data name="Arguments" xml:space="preserve">
+    <value>Argomenti</value>
+  </data>
+  <data name="StartInDirectory" xml:space="preserve">
+    <value>Directory di avvio</value>
+  </data>
+  <data name="EnterActionName" xml:space="preserve">
+    <value>Inserisci il nome dell'azione</value>
+  </data>
+  <data name="PathToExecutable" xml:space="preserve">
+    <value>Percorso dell'eseguibile</value>
+  </data>
+  <data name="CommandLineArguments" xml:space="preserve">
+    <value>Argomenti della riga di comando (facoltativo)</value>
+  </data>
+  <data name="EnterPassword" xml:space="preserve">
+    <value>Inserisci la password</value>
+  </data>
+  <data name="EnterPasswordDescription" xml:space="preserve">
+    <value>Inserisci la password di sblocco del dispositivo per continuare.</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Reply" xml:space="preserve">
+    <value>Rispondi</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Indietro</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Sfoglia</value>
+  </data>
+  <data name="EnterAddressesAndCompose" xml:space="preserve">
+    <value>Inserisci gli indirizzi sopra e scrivi il messaggio qui sotto</value>
+  </data>
+  <data name="UseTcpIpMode" xml:space="preserve">
+    <value>Usa la modalità TCP/IP</value>
+  </data>
+  <data name="UseTcpIpModeDescription" xml:space="preserve">
+    <value>Abilita le connessioni ADB wireless</value>
+  </data>
+  <data name="WorkingDirectory" xml:space="preserve">
+    <value>Directory di lavoro (facoltativo)</value>
+  </data>
+  <data name="UnlockDeviceBeforeLaunch" xml:space="preserve">
+    <value>Sblocca il dispositivo prima di avviare scrcpy</value>
+  </data>
+  <data name="UnlockCommandsHeader" xml:space="preserve">
+    <value>Comandi di sblocco</value>
+  </data>
+  <data name="NewUnlockCommand" xml:space="preserve">
+    <value>Nuovo comando</value>
+  </data>
+  <data name="PasswordCacheTimeout" xml:space="preserve">
+    <value>Timeout della cache della password</value>
+  </data>
+  <data name="PasswordCacheTimeoutDescription" xml:space="preserve">
+    <value>Se impostato a 0, la password verrà richiesta ogni volta. Se impostato a un valore maggiore di 0, la password verrà memorizzata per il numero di minuti indicato e riutilizzata automaticamente.</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Salva</value>
+  </data>
+  <data name="FileTransferNotification.Receiving" xml:space="preserve">
+    <value>Ricezione da {0}</value>
+  </data>
+  <data name="FileTransferNotification.Sending" xml:space="preserve">
+    <value>Invio a {0}</value>
+  </data>
+  <data name="FileTransferNotification.ReceivingBulk" xml:space="preserve">
+    <value>Ricezione di {0} file da {1}</value>
+  </data>
+  <data name="FileTransferNotification.SendingBulk" xml:space="preserve">
+    <value>Invio di {0} file a {1}</value>
+  </data>
+  <data name="FileTransferNotification.Completed" xml:space="preserve">
+    <value>Trasferimento file completato</value>
+  </data>
+  <data name="FileTransferNotification.Failed" xml:space="preserve">
+    <value>Trasferimento file non riuscito</value>
+  </data>
+  <data name="FileTransferNotification.FailedTo" xml:space="preserve">
+    <value>Trasferimento verso {0} non riuscito</value>
+  </data>
+  <data name="FileTransferNotification.FailedFrom" xml:space="preserve">
+    <value>Trasferimento da {0} non riuscito</value>
+  </data>
+  <data name="FileTransferNotification.CompletedSingle" xml:space="preserve">
+    <value>Ricevuto {0} da {1}</value>
+  </data>
+  <data name="FileTransferNotification.CompletedBulk" xml:space="preserve">
+    <value>Ricevuti {0} file da {1}</value>
+  </data>
+  <data name="FileTransferNotification.SentSingle" xml:space="preserve">
+    <value>Inviato {0} a {1}</value>
+  </data>
+  <data name="FileTransferNotification.SentBulk" xml:space="preserve">
+    <value>Inviati {0} file a {1}</value>
+  </data>
+  <data name="FileTransferNotificationAction.Cancel" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="NoPairedDevices" xml:space="preserve">
+    <value>Nessun dispositivo associato</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Aggiungi</value>
+  </data>
+  <data name="HostnamePlaceholder" xml:space="preserve">
+    <value>Inserisci nome host o indirizzo IP</value>
+  </data>
+  <data name="UnlockCommandsPlaceholder" xml:space="preserve">
+    <value>input keyevent 26
+input keyevent 66
+input text %pwd%</value>
+  </data>
+  <data name="UnlockCommandPlaceholder" xml:space="preserve">
+    <value>input keyevent 26</value>
+  </data>
+  <data name="MicrosecondsLabel" xml:space="preserve">
+    <value>ms</value>
+  </data>
+  <data name="Delay" xml:space="preserve">
+    <value>Ritardo</value>
+  </data>
+  <data name="FileDropCaption" xml:space="preserve">
+    <value>Rilascia i file per inviarli</value>
+  </data>
+  <data name="DeviceAddresses" xml:space="preserve">
+    <value>Indirizzi del dispositivo</value>
+  </data>
+  <data name="ManageAddressesAndPriority" xml:space="preserve">
+    <value>Gestisci gli indirizzi e la priorità di connessione</value>
+  </data>
+  <data name="StorageAccess" xml:space="preserve">
+    <value>Mostra il dispositivo in Esplora file</value>
+  </data>
+  <data name="StorageAccessDescription" xml:space="preserve">
+    <value>Abilita o disabilita l'accesso all'archiviazione di questo dispositivo in Esplora file</value>
+  </data>
+  <data name="AudioSilent" xml:space="preserve">
+    <value>Silenzioso</value>
+  </data>
+  <data name="AudioVibrate" xml:space="preserve">
+    <value>Vibrazione</value>
+  </data>
+  <data name="AudioRing" xml:space="preserve">
+    <value>Suoneria</value>
+  </data>
+  <data name="AudioMedia" xml:space="preserve">
+    <value>Contenuti multimediali</value>
+  </data>
+  <data name="AudioNotification" xml:space="preserve">
+    <value>Notifica</value>
+  </data>
+  <data name="AudioCall" xml:space="preserve">
+    <value>Chiamata</value>
+  </data>
+  <data name="AudioAlarm" xml:space="preserve">
+    <value>Sveglia</value>
+  </data>
+  <data name="AdbSettingsDescription" xml:space="preserve">
+    <value>Configura la connessione ADB</value>
+  </data>
+  <data name="ScreenMirrorSettingsDescription" xml:space="preserve">
+    <value>Configura i flag di scrcpy e le opzioni di mirroring dello schermo</value>
+  </data>
+  <data name="MediaSessionDescription" xml:space="preserve">
+    <value>Sincronizza le informazioni di riproduzione multimediale con questo dispositivo</value>
+  </data>
+  <data name="AudioControl" xml:space="preserve">
+    <value>Controllo del dispositivo audio</value>
+  </data>
+  <data name="MediaSession" xml:space="preserve">
+    <value>Sessione di riproduzione multimediale</value>
+  </data>
+  <data name="AudioControlDescription" xml:space="preserve">
+    <value>Consenti il controllo del dispositivo audio con questo dispositivo</value>
+  </data>
+  <data name="ClipboardIncludeImagesDescription" xml:space="preserve">
+    <value>Abilita la sincronizzazione delle immagini tramite gli appunti</value>
+  </data>
+  <data name="ClipboardIncludeImages" xml:space="preserve">
+    <value>Includi le immagini nel monitoraggio degli appunti</value>
+  </data>
+  <data name="Language" xml:space="preserve">
+    <value>Lingua</value>
+  </data>
+  <data name="LanguageDescription" xml:space="preserve">
+    <value>Scegli la lingua di visualizzazione preferita</value>
+  </data>
+  <data name="UseSystemSetting" xml:space="preserve">
+    <value>Usa l'impostazione di sistema</value>
+  </data>
+  <data name="ScrcpyLocation" xml:space="preserve">
+    <value>Percorso di scrcpy</value>
+  </data>
+  <data name="AdbLocation" xml:space="preserve">
+    <value>Percorso di ADB</value>
+  </data>
+  <data name="CallMissed" xml:space="preserve">
+    <value>Chiamata persa</value>
+  </data>
+  <data name="UpdateNotification.Title" xml:space="preserve">
+    <value>Aggiornamento disponibile</value>
+  </data>
+  <data name="UpdateNotification.Action" xml:space="preserve">
+    <value>Scarica aggiornamento</value>
+  </data>
+  <data name="UpdateNotification.Subtitle" xml:space="preserve">
+    <value>È disponibile una nuova versione</value>
+  </data>
+  <data name="ClipboardNotification.Title" xml:space="preserve">
+    <value>Appunti ricevuti</value>
+  </data>
+  <data name="BatteryNotification.Title" xml:space="preserve">
+    <value>Batteria scarica</value>
+  </data>
+  <data name="BatteryNotification.Text" xml:space="preserve">
+    <value>{0} è al {1}% di batteria.</value>
+  </data>
+  <data name="OpenInBrowser" xml:space="preserve">
+    <value>Apri nel browser</value>
+  </data>
+  <data name="PhoneFrameScrollTip" xml:space="preserve">
+    <value>Scorri sull'anteprima del telefono per cambiare il dispositivo attivo</value>
+  </data>
+  <data name="AddAppShortcut" xml:space="preserve">
+    <value>Aggiungi collegamento</value>
+  </data>
+  <data name="RemoveAppShortcut" xml:space="preserve">
+    <value>Rimuovi collegamento</value>
+  </data>
+  <data name="DeviceAudio" xml:space="preserve">
+    <value>Audio del dispositivo</value>
+  </data>
+  <data name="DndToggle" xml:space="preserve">
+    <value>Attiva/disattiva Non disturbare</value>
+  </data>
+  <data name="StartScreenMirroring" xml:space="preserve">
+    <value>Avvia il mirroring dello schermo</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Connetti</value>
+  </data>
+  <data name="Disconnect" xml:space="preserve">
+    <value>Disconnetti</value>
+  </data>
+  <data name="PreviousTrack" xml:space="preserve">
+    <value>Traccia precedente</value>
+  </data>
+  <data name="PlayOrPause" xml:space="preserve">
+    <value>Riproduci o metti in pausa</value>
+  </data>
+  <data name="NextTrack" xml:space="preserve">
+    <value>Traccia successiva</value>
+  </data>
+  <data name="MediaVolume" xml:space="preserve">
+    <value>Volume multimediale</value>
+  </data>
+  <data name="SendNotificationReply" xml:space="preserve">
+    <value>Invia risposta alla notifica</value>
+  </data>
+  <data name="RefreshApps" xml:space="preserve">
+    <value>Aggiorna app</value>
+  </data>
+  <data name="InstallApp" xml:space="preserve">
+    <value>Installa app</value>
+  </data>
+  <data name="ContextMenu" xml:space="preserve">
+    <value>Menu contestuale</value>
+  </data>
+  <data name="ShareFiles" xml:space="preserve">
+    <value>Condividi file</value>
+  </data>
+  <data name="SendFiles" xml:space="preserve">
+    <value>Invia file</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Sfoglia file</value>
+  </data>
+  <data name="BrowseFilesTooltip" xml:space="preserve">
+    <value>Fai clic con il tasto destro per aprire il link SFTP e copiarlo negli appunti</value>
+  </data>
+  <data name="DeviceActions" xml:space="preserve">
+    <value>Azioni</value>
+  </data>
+  <data name="PlaySound" xml:space="preserve">
+    <value>Riproduci suono</value>
+  </data>
+  <data name="PlaySoundDescription" xml:space="preserve">
+    <value>Sul dispositivo verrà riprodotto un suono per 20 secondi</value>
+  </data>
+  <data name="ReceiveClipboard" xml:space="preserve">
+    <value>Ricevi appunti</value>
+  </data>
+  <data name="SendClipboard" xml:space="preserve">
+    <value>Invia appunti</value>
+  </data>
+  <data name="ReceiveMediaSessions" xml:space="preserve">
+    <value>Ricevi sessioni multimediali</value>
+  </data>
+  <data name="SendMediaSessions" xml:space="preserve">
+    <value>Invia sessioni multimediali</value>
+  </data>
+  <data name="SecondaryCallOnHold" xml:space="preserve">
+    <value>In attesa. Seleziona per riprendere</value>
+  </data>
+  <data name="CallLogDisabled.Description" xml:space="preserve">
+    <value>Abilita la sincronizzazione del registro chiamate per questo dispositivo dal telefono.</value>
+  </data>
+  <data name="BluetoothCallingUnsupported" xml:space="preserve">
+    <value>Le chiamate via Bluetooth non sono supportate</value>
+  </data>
+  <data name="BluetoothCallingUnavailable.Description" xml:space="preserve">
+    <value>Collega o abilita un adattatore Bluetooth sul PC per continuare.</value>
+  </data>
+  <data name="BluetoothDisabled.Description" xml:space="preserve">
+    <value>Abilita il Bluetooth per continuare.</value>
+  </data>
+  <data name="BluetoothPairing.Title" xml:space="preserve">
+    <value>Associa il dispositivo mobile e il PC</value>
+  </data>
+  <data name="BluetoothPairing.Description" xml:space="preserve">
+    <value>Assicurati che il dispositivo sia nelle vicinanze e abbia il Bluetooth attivo.</value>
+  </data>
+  <data name="BluetoothPairingAction" xml:space="preserve">
+    <value>Associa dispositivo</value>
+  </data>
+  <data name="BluetoothRegistrationFailed.Description" xml:space="preserve">
+    <value>Rimuovi l'associazione del dispositivo dalle altre app e riprova.</value>
+  </data>
+  <data name="TryAgain" xml:space="preserve">
+    <value>Riprova</value>
+  </data>
+  <data name="SearchContacts" xml:space="preserve">
+    <value>Cerca contatti</value>
+  </data>
+  <data name="BluetoothRegistrationFailed.Title" xml:space="preserve">
+    <value>Registrazione non riuscita</value>
+  </data>
+  <data name="BluetoothCallingUnavailable.Title" xml:space="preserve">
+    <value>Le chiamate via Bluetooth non sono disponibili</value>
+  </data>
+  <data name="BluetoothDisabled.Title" xml:space="preserve">
+    <value>Il Bluetooth è disattivato</value>
+  </data>
+  <data name="Calls" xml:space="preserve">
+    <value>Chiamate</value>
+  </data>
+  <data name="Unmute" xml:space="preserve">
+    <value>Riattiva microfono</value>
+  </data>
+  <data name="Resume" xml:space="preserve">
+    <value>Riprendi</value>
+  </data>
+  <data name="Mute" xml:space="preserve">
+    <value>Disattiva microfono</value>
+  </data>
+  <data name="Hold" xml:space="preserve">
+    <value>Metti in attesa</value>
+  </data>
+  <data name="End" xml:space="preserve">
+    <value>Termina</value>
+  </data>
+  <data name="CallOnHold" xml:space="preserve">
+    <value>In attesa</value>
+  </data>
+  <data name="CallIncoming" xml:space="preserve">
+    <value>Chiamata in arrivo</value>
+  </data>
+  <data name="CallDialing" xml:space="preserve">
+    <value>Composizione</value>
+  </data>
+  <data name="CallConnecting" xml:space="preserve">
+    <value>Connessione</value>
+  </data>
+  <data name="CallAudioRouteToPhone" xml:space="preserve">
+    <value>Trasferisci al telefono</value>
+  </data>
+  <data name="CallAudioRouteToPc" xml:space="preserve">
+    <value>Trasferisci al PC</value>
+  </data>
+  <data name="FlexDisplay" xml:space="preserve">
+    <value>Schermo flessibile</value>
+  </data>
+  <data name="VideoBitratePlaceholder" xml:space="preserve">
+    <value>8M</value>
+  </data>
+  <data name="VideoBitrateToolTip" xml:space="preserve">
+    <value>Formato: 8M, 8000000</value>
+  </data>
+  <data name="AudioBitratePlaceholder" xml:space="preserve">
+    <value>128K</value>
+  </data>
+  <data name="AudioBitrateToolTip" xml:space="preserve">
+    <value>Formato: 128K, 128000</value>
+  </data>
+  <data name="CropPlaceholder" xml:space="preserve">
+    <value>Nessun ritaglio</value>
+  </data>
+  <data name="CropToolTip" xml:space="preserve">
+    <value>Formato: 1224:1440:0:0</value>
+  </data>
+  <data name="VirtualDisplaySizePlaceholder" xml:space="preserve">
+    <value>Valore predefinito del dispositivo</value>
+  </data>
+  <data name="VirtualDisplaySizeToolTip" xml:space="preserve">
+    <value>Formato: 1920x1080</value>
+  </data>
+  <data name="VideoBitrateMbps" xml:space="preserve">
+    <value>Mbps</value>
+  </data>
+  <data name="RemoveAllStorageMounts" xml:space="preserve">
+    <value>Rimuovi tutti i montaggi di archiviazione</value>
+  </data>
+  <data name="RemoveAllStorageMountsDescription" xml:space="preserve">
+    <value>Smonta ed elimina tutte le archiviazioni dei dispositivi registrate dall'app</value>
+   </data>
+</root>

--- a/src/Sefirah/Utils/DeviceSftpConnection.cs
+++ b/src/Sefirah/Utils/DeviceSftpConnection.cs
@@ -1,0 +1,117 @@
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using Renci.SshNet;
+using Renci.SshNet.Common;
+using Sefirah.Data.Models;
+
+namespace Sefirah.Utils;
+
+/// <summary>
+/// Owns an SFTP connection to the active device, rebuilding it whenever the device restarts its
+/// server. Each page keeps its own instance so their requests never interleave on one channel.
+/// </summary>
+public sealed class DeviceSftpConnection
+{
+    /// <summary>
+    /// A per-run key pair used only to authenticate against the device's own SFTP server.
+    /// </summary>
+    private static readonly Lazy<PrivateKeyFile> SessionKey = new(() =>
+    {
+        using var rsa = RSA.Create(2048);
+        using var pem = new MemoryStream(Encoding.ASCII.GetBytes(rsa.ExportPkcs8PrivateKeyPem()));
+        return new PrivateKeyFile(pem);
+    });
+
+    private readonly ILogger logger = Ioc.Default.GetRequiredService<ILogger>();
+    private readonly IDeviceManager deviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly ISftpFeature sftpFeature = Ioc.Default.GetRequiredService<ISftpFeature>();
+    private readonly object gate = new();
+
+    private SftpClient? client;
+
+    /// <summary>
+    /// Re-reads the endpoint every time: the device generates a fresh password whenever its
+    /// SFTP server restarts, so a cached one goes stale without warning.
+    /// </summary>
+    public SftpSession? CurrentSession()
+    {
+        var device = deviceManager.ActiveDevice;
+        return device is null ? null : sftpFeature.GetSession(device.Id);
+    }
+
+    /// <summary>
+    /// Runs an SFTP call off the UI thread, reconnecting once if the device dropped off the network
+    /// in the meantime, which it does every time it leaves Wi-Fi.
+    /// </summary>
+    public Task<T> RunAsync<T>(Func<SftpClient, T> operation) => Task.Run(() =>
+    {
+        // Only worth retrying a connection that was alive; retrying a fresh connect just doubles the wait
+        var hadConnection = client is not null;
+        try
+        {
+            return operation(Connect());
+        }
+        catch (Exception ex) when (hadConnection && ex is SshException or ObjectDisposedException or IOException or SocketException)
+        {
+            logger.Warn($"SFTP call failed, reconnecting once: {ex.Message}");
+            Drop();
+            return operation(Connect());
+        }
+    });
+
+    public void Drop()
+    {
+        lock (gate)
+        {
+            try
+            {
+                client?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.Warn($"Failed to close the SFTP connection: {ex.Message}", ex);
+            }
+            client = null;
+        }
+    }
+
+    /// <summary>
+    /// True when the failure means the device is off the network rather than the call being wrong.
+    /// A device that walks away gives no notification, the connection attempt simply times out.
+    /// </summary>
+    public static bool IsUnreachable(Exception ex)
+        => ex is SshOperationTimeoutException or SshConnectionException or SocketException or IOException;
+
+    private SftpClient Connect()
+    {
+        lock (gate)
+        {
+            if (client is { IsConnected: true }) return client;
+
+            var current = CurrentSession()
+                ?? throw new InvalidOperationException("The device has not announced an SFTP endpoint");
+
+            client?.Dispose();
+            logger.Info($"Connecting to SFTP {current.Host}:{current.Port} as {current.Username}");
+
+            // The announced password goes stale as soon as the device restarts its SFTP server, and the
+            // server accepts any public key, so keep a throwaway key as a fallback for that window.
+            var connectionInfo = new ConnectionInfo(current.Host, current.Port, current.Username,
+                new PasswordAuthenticationMethod(current.Username, current.Password),
+                new PrivateKeyAuthenticationMethod(current.Username, SessionKey.Value))
+            {
+                Timeout = TimeSpan.FromSeconds(10)
+            };
+
+            var sftp = new SftpClient(connectionInfo)
+            {
+                OperationTimeout = TimeSpan.FromSeconds(30),
+                KeepAliveInterval = TimeSpan.FromSeconds(15)
+            };
+            sftp.Connect();
+            client = sftp;
+            return sftp;
+        }
+    }
+}

--- a/src/Sefirah/Utils/ExifThumbnail.cs
+++ b/src/Sefirah/Utils/ExifThumbnail.cs
@@ -1,0 +1,123 @@
+using System.Buffers.Binary;
+
+namespace Sefirah.Utils;
+
+/// <summary>
+/// Pulls the small preview most cameras embed in a JPEG's EXIF block. Reading it costs a few
+/// kilobytes off the head of the file, against megabytes for the real image, which is the
+/// difference between a gallery that fills in at once and one that crawls over the network.
+/// </summary>
+public static class ExifThumbnail
+{
+    private const ushort JpegInterchangeFormat = 0x0201;
+    private const ushort JpegInterchangeFormatLength = 0x0202;
+
+    /// <summary>
+    /// Returns the embedded preview found in <paramref name="head"/>, the first bytes of a JPEG,
+    /// or null when the file carries none.
+    /// </summary>
+    public static byte[]? TryExtract(ReadOnlySpan<byte> head)
+    {
+        try
+        {
+            var app1 = FindExifApp1(head);
+            if (app1 < 0) return null;
+
+            // The TIFF header the EXIF offsets are relative to starts right after "Exif\0\0"
+            var tiff = app1 + 6;
+            if (tiff + 8 > head.Length) return null;
+
+            var little = head[tiff] == 0x49 && head[tiff + 1] == 0x49;
+            if (!little && !(head[tiff] == 0x4D && head[tiff + 1] == 0x4D)) return null;
+
+            var ifd0 = tiff + (int)ReadUInt32(head, tiff + 4, little);
+            var ifd1 = ReadNextIfdOffset(head, tiff, ifd0, little);
+            if (ifd1 <= 0) return null;
+
+            // IFD1 describes the thumbnail: where it starts and how long it is
+            var offset = 0;
+            var length = 0;
+            foreach (var (tag, value) in ReadEntries(head, tiff, tiff + ifd1, little))
+            {
+                if (tag == JpegInterchangeFormat) offset = (int)value;
+                else if (tag == JpegInterchangeFormatLength) length = (int)value;
+            }
+
+            if (offset <= 0 || length <= 0) return null;
+
+            var start = tiff + offset;
+            if (start < 0 || start + length > head.Length) return null;
+
+            return head.Slice(start, length).ToArray();
+        }
+        catch
+        {
+            // A malformed header is not worth reporting, the caller just falls back to the real image
+            return null;
+        }
+    }
+
+    private static int FindExifApp1(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 4 || data[0] != 0xFF || data[1] != 0xD8) return -1;
+
+        var position = 2;
+        while (position + 4 <= data.Length)
+        {
+            if (data[position] != 0xFF) return -1;
+
+            var marker = data[position + 1];
+            if (marker is 0xD8 or 0x01 || (marker >= 0xD0 && marker <= 0xD7))
+            {
+                position += 2;
+                continue;
+            }
+            if (marker == 0xDA) return -1; // start of scan, no metadata past here
+
+            var segmentLength = BinaryPrimitives.ReadUInt16BigEndian(data[(position + 2)..]);
+            if (marker == 0xE1 && position + 10 <= data.Length &&
+                data.Slice(position + 4, 4).SequenceEqual("Exif"u8))
+            {
+                return position + 4;
+            }
+
+            position += 2 + segmentLength;
+        }
+        return -1;
+    }
+
+    private static int ReadNextIfdOffset(ReadOnlySpan<byte> data, int tiff, int ifd, bool little)
+    {
+        if (ifd + 2 > data.Length) return 0;
+
+        var count = ReadUInt16(data, ifd, little);
+        var next = ifd + 2 + count * 12;
+        return next + 4 > data.Length ? 0 : (int)ReadUInt32(data, next, little);
+    }
+
+    private static List<(ushort Tag, uint Value)> ReadEntries(ReadOnlySpan<byte> data, int tiff, int ifd, bool little)
+    {
+        List<(ushort, uint)> entries = [];
+        if (ifd + 2 > data.Length) return entries;
+
+        var count = ReadUInt16(data, ifd, little);
+        for (var i = 0; i < count; i++)
+        {
+            var entry = ifd + 2 + i * 12;
+            if (entry + 12 > data.Length) break;
+
+            entries.Add((ReadUInt16(data, entry, little), ReadUInt32(data, entry + 8, little)));
+        }
+        return entries;
+    }
+
+    private static ushort ReadUInt16(ReadOnlySpan<byte> data, int offset, bool little)
+        => little
+            ? BinaryPrimitives.ReadUInt16LittleEndian(data[offset..])
+            : BinaryPrimitives.ReadUInt16BigEndian(data[offset..]);
+
+    private static uint ReadUInt32(ReadOnlySpan<byte> data, int offset, bool little)
+        => little
+            ? BinaryPrimitives.ReadUInt32LittleEndian(data[offset..])
+            : BinaryPrimitives.ReadUInt32BigEndian(data[offset..]);
+}

--- a/src/Sefirah/Utils/LocalAppPaths.cs
+++ b/src/Sefirah/Utils/LocalAppPaths.cs
@@ -6,6 +6,7 @@ public static class LocalAppPaths
     public const string DeviceSettingsFileName = "settings.json";
     public const string DeviceIconsFolderName = "Icons";
     public const string ClipboardFolderName = "Clipboard";
+    public const string ClipboardHistoryFolderName = "ClipboardHistory";
     public const string UserSettingsFileName = "user_settings.json";
 
     private static readonly TimeSpan TemporaryFileMaxAge = TimeSpan.FromHours(24);
@@ -38,6 +39,25 @@ public static class LocalAppPaths
             ? ".png"
             : extension[0] == '.' ? extension : $".{extension}";
         return Path.Combine(GetClipboardFolder(), $"clipboard_{Guid.NewGuid():N}{ext}");
+    }
+
+    /// <summary>
+    /// Clipboard images live in the temporary folder, which is pruned daily. History entries need to
+    /// outlive that, so their images are kept here instead.
+    /// </summary>
+    public static string GetClipboardHistoryFolder()
+    {
+        var path = Path.Combine(LocalFolder, ClipboardHistoryFolderName);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    public static string CreateClipboardHistoryFilePath(string? extension)
+    {
+        var ext = string.IsNullOrWhiteSpace(extension)
+            ? ".png"
+            : extension[0] == '.' ? extension : $".{extension}";
+        return Path.Combine(GetClipboardHistoryFolder(), $"clipboard_{Guid.NewGuid():N}{ext}");
     }
 
     public static void PruneTemporaryFolder()

--- a/src/Sefirah/ViewModels/ClipboardViewModel.cs
+++ b/src/Sefirah/ViewModels/ClipboardViewModel.cs
@@ -1,0 +1,188 @@
+using CommunityToolkit.WinUI;
+using Sefirah.Data.AppDatabase.Repository;
+using Sefirah.Data.Models;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+
+namespace Sefirah.ViewModels;
+
+/// <summary>
+/// The history of what the device has copied. Android keeps none of its own, so this is built here
+/// from the items the device sends as they happen.
+/// </summary>
+public sealed partial class ClipboardViewModel : BaseViewModel
+{
+    #region Services
+    private readonly IDeviceManager DeviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly IClipboardFeature ClipboardFeature = Ioc.Default.GetRequiredService<IClipboardFeature>();
+    private readonly ClipboardRepository Repository = Ioc.Default.GetRequiredService<ClipboardRepository>();
+    #endregion
+
+    private bool listening;
+    private string? boundDeviceId;
+
+    public ObservableCollection<ClipboardEntry> Entries { get; } = [];
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial string? StatusMessage { get; set; }
+
+    [ObservableProperty]
+    public partial ClipboardEntry? SelectedEntry { get; set; }
+
+    public bool HasStatus => !string.IsNullOrEmpty(StatusMessage);
+
+    partial void OnStatusMessageChanged(string? value) => OnPropertyChanged(nameof(HasStatus));
+
+    #region Lifetime
+
+    public async Task InitializeAsync()
+    {
+        if (!listening)
+        {
+            ClipboardFeature.HistoryChanged += OnHistoryChanged;
+            listening = true;
+        }
+
+        await LoadAsync();
+    }
+
+    public void Suspend()
+    {
+        if (!listening) return;
+
+        ClipboardFeature.HistoryChanged -= OnHistoryChanged;
+        listening = false;
+    }
+
+    private void OnHistoryChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+
+        dispatcher.TryEnqueue(async () => await LoadAsync());
+    }
+
+    private async Task LoadAsync()
+    {
+        var device = DeviceManager.ActiveDevice;
+        boundDeviceId = device?.Id;
+
+        if (device is null)
+        {
+            Entries.Clear();
+            StatusMessage = "ClipboardNoDevice".GetLocalizedResource();
+            return;
+        }
+
+        IsLoading = true;
+        try
+        {
+            var entries = await Repository.GetEntriesAsync(device.Id);
+
+            Entries.Clear();
+            foreach (var entry in entries)
+            {
+                Entries.Add(entry);
+            }
+
+            StatusMessage = Entries.Count == 0 ? "ClipboardEmpty".GetLocalizedResource() : null;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to load clipboard history: {ex.Message}", ex);
+            StatusMessage = ex.Message;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    #endregion
+
+    #region Commands
+
+    [RelayCommand]
+    private Task Refresh() => LoadAsync();
+
+    /// <summary>
+    /// Puts a past item back on the Windows clipboard, which is the whole point of keeping them.
+    /// </summary>
+    [RelayCommand]
+    private async Task Copy(ClipboardEntry? entry)
+    {
+        if (entry is null) return;
+
+        try
+        {
+            var package = new DataPackage { RequestedOperation = DataPackageOperation.Copy };
+
+            if (entry.IsImage)
+            {
+                if (!File.Exists(entry.Content))
+                {
+                    StatusMessage = "ClipboardImageMissing".GetLocalizedResource();
+                    return;
+                }
+
+                var file = await StorageFile.GetFileFromPathAsync(entry.Content);
+                package.Properties.PackageFamilyName = Package.Current.Id.FamilyName;
+                package.SetBitmap(RandomAccessStreamReference.CreateFromFile(file));
+                package.SetStorageItems([file], false);
+            }
+            else
+            {
+                package.SetText(entry.Content);
+            }
+
+            Clipboard.SetContent(package);
+            StatusMessage = null;
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to copy history entry: {ex.Message}", ex);
+            StatusMessage = ex.Message;
+        }
+    }
+
+    [RelayCommand]
+    private async Task Delete(ClipboardEntry? entry)
+    {
+        if (entry is null) return;
+
+        await Repository.DeleteAsync(entry.Id);
+        Entries.Remove(entry);
+
+        if (Entries.Count == 0)
+        {
+            StatusMessage = "ClipboardEmpty".GetLocalizedResource();
+        }
+    }
+
+    [RelayCommand]
+    private async Task Clear()
+    {
+        if (boundDeviceId is null || Entries.Count == 0) return;
+
+        var dialog = new ContentDialog
+        {
+            Title = "ClipboardClearTitle".GetLocalizedResource(),
+            Content = "ClipboardClearSubtitle".GetLocalizedResource(),
+            PrimaryButtonText = "Remove".GetLocalizedResource(),
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        if (await dialog.ShowAsync() is not ContentDialogResult.Primary) return;
+
+        await Repository.ClearAsync(boundDeviceId);
+        Entries.Clear();
+        StatusMessage = "ClipboardEmpty".GetLocalizedResource();
+    }
+
+    #endregion
+}

--- a/src/Sefirah/ViewModels/FilesViewModel.cs
+++ b/src/Sefirah/ViewModels/FilesViewModel.cs
@@ -1,0 +1,478 @@
+using Renci.SshNet;
+using Sefirah.Data.Models;
+using Sefirah.Utils;
+
+namespace Sefirah.ViewModels;
+
+/// <summary>
+/// Browses the device filesystem over the SFTP endpoint the device announces while connected,
+/// independently of whether the platform managed to mount it locally.
+/// </summary>
+public sealed partial class FilesViewModel : BaseViewModel
+{
+    #region Services
+    private readonly IDeviceManager DeviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly ISftpFeature SftpFeature = Ioc.Default.GetRequiredService<ISftpFeature>();
+    private readonly ISessionManager SessionManager = Ioc.Default.GetRequiredService<ISessionManager>();
+    #endregion
+
+    // One navigation at a time: overlapping listings fight over the connection and over the bound collections
+    private readonly SemaphoreSlim navigationLock = new(1, 1);
+    private readonly DeviceSftpConnection connection = new();
+
+    private bool listening;
+    private string? boundDeviceId;
+    private string rootPath = "/";
+    private string currentPath = "/";
+
+    public ObservableCollection<RemoteFileItem> Items { get; } = [];
+
+    /// <summary>
+    /// Replaced wholesale rather than mutated: BreadcrumbBar does not survive its source being
+    /// cleared and refilled item by item.
+    /// </summary>
+    [ObservableProperty]
+    public partial IReadOnlyList<string> PathSegments { get; set; } = [];
+
+    [ObservableProperty]
+    public partial IReadOnlyList<string> Volumes { get; set; } = [];
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsBusy { get; set; }
+
+    [ObservableProperty]
+    public partial string? StatusMessage { get; set; }
+
+    [ObservableProperty]
+    public partial int SelectedVolumeIndex { get; set; }
+
+    public bool HasMultipleVolumes => Volumes.Count > 1;
+
+    public bool CanGoUp => currentPath.TrimEnd('/') != rootPath.TrimEnd('/');
+
+    public bool HasStatus => !string.IsNullOrEmpty(StatusMessage);
+
+    partial void OnStatusMessageChanged(string? value) => OnPropertyChanged(nameof(HasStatus));
+
+    partial void OnVolumesChanged(IReadOnlyList<string> value) => OnPropertyChanged(nameof(HasMultipleVolumes));
+
+    partial void OnSelectedVolumeIndexChanged(int value)
+    {
+        var paths = connection.CurrentSession()?.Paths;
+        if (paths is null || value < 0 || value >= paths.Count) return;
+
+        // The ComboBox echoes the volume back while its source is being set up; only act on a real change
+        if (paths[value].TrimEnd('/') == rootPath.TrimEnd('/')) return;
+
+        rootPath = paths[value];
+        _ = NavigateAsync(rootPath);
+    }
+
+    #region Lifetime
+
+    /// <summary>
+    /// Picks up the endpoint of the currently active device and lists its root.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        if (!listening)
+        {
+            SftpFeature.SessionChanged += OnSessionChanged;
+            SessionManager.ConnectionStatusChanged += OnConnectionStatusChanged;
+            listening = true;
+        }
+
+        await LoadRootAsync();
+    }
+
+    /// <summary>
+    /// Stops following the device and drops the connection, so it is not kept busy while the page is away.
+    /// </summary>
+    public void Suspend()
+    {
+        if (listening)
+        {
+            SftpFeature.SessionChanged -= OnSessionChanged;
+            SessionManager.ConnectionStatusChanged -= OnConnectionStatusChanged;
+            listening = false;
+        }
+
+        connection.Drop();
+    }
+
+    /// <summary>
+    /// The device announced a new endpoint, which means new credentials: rebuild and stay where the user was.
+    /// </summary>
+    private void OnSessionChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+
+        connection.Drop();
+        dispatcher.TryEnqueue(async () =>
+        {
+            var current = connection.CurrentSession();
+            if (current is null) return;
+
+            var paths = current.Paths.Count > 0 ? current.Paths : ["/"];
+            rootPath = paths[Math.Clamp(SelectedVolumeIndex, 0, paths.Count - 1)];
+
+            // Come back to the folder the user was looking at, falling back to the root if it is gone
+            var target = currentPath.StartsWith(rootPath, StringComparison.Ordinal) ? currentPath : rootPath;
+            await NavigateAsync(target);
+        });
+    }
+
+    private void OnConnectionStatusChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+        if (device.IsConnected) return;
+
+        connection.Drop();
+        dispatcher.TryEnqueue(() =>
+        {
+            Items.Clear();
+            StatusMessage = "FilesDisconnected".GetLocalizedResource();
+        });
+    }
+
+    private async Task LoadRootAsync()
+    {
+        boundDeviceId = DeviceManager.ActiveDevice?.Id;
+        var current = connection.CurrentSession();
+        Items.Clear();
+
+        if (current is null)
+        {
+            Volumes = [];
+            PathSegments = [];
+            StatusMessage = "FilesUnavailable".GetLocalizedResource();
+            return;
+        }
+
+        var paths = current.Paths.Count > 0 ? current.Paths : ["/"];
+
+        // Set the root before the index, so the change handler recognises the echo and stays quiet
+        rootPath = paths[0];
+        Volumes = [.. paths.Select((path, i) => current.PathNames.Count > i ? current.PathNames[i] : path)];
+        SelectedVolumeIndex = 0;
+
+        await NavigateAsync(rootPath);
+    }
+
+    #endregion
+
+    #region Navigation
+
+    [RelayCommand]
+    private Task Refresh() => NavigateAsync(currentPath);
+
+    [RelayCommand]
+    private Task GoUp()
+    {
+        if (!CanGoUp) return Task.CompletedTask;
+
+        var parent = currentPath.TrimEnd('/');
+        var separator = parent.LastIndexOf('/');
+        parent = separator <= 0 ? "/" : parent[..separator];
+        return NavigateAsync(parent);
+    }
+
+    /// <summary>
+    /// Navigates to the breadcrumb segment at <paramref name="index"/>, 0 being the volume root.
+    /// </summary>
+    public Task NavigateToSegmentAsync(int index)
+    {
+        if (index < 0 || index >= PathSegments.Count) return Task.CompletedTask;
+
+        var path = rootPath.TrimEnd('/');
+        for (var i = 1; i <= index; i++)
+        {
+            path += "/" + PathSegments[i];
+        }
+        return NavigateAsync(string.IsNullOrEmpty(path) ? "/" : path);
+    }
+
+    [RelayCommand]
+    private async Task Open(RemoteFileItem? item)
+    {
+        if (item is null) return;
+
+        if (item.IsDirectory)
+        {
+            await NavigateAsync(item.FullPath);
+            return;
+        }
+
+        await RunAsync(async () =>
+        {
+            // Files are streamed to a temp copy first, there is nothing to open in place over SFTP
+            var local = Path.Combine(Path.GetTempPath(), "Sefirah", item.Name);
+            Directory.CreateDirectory(Path.GetDirectoryName(local)!);
+
+            await connection.RunAsync(sftp =>
+            {
+                using var stream = File.Create(local);
+                sftp.DownloadFile(item.FullPath, stream);
+                return true;
+            });
+
+            Process.Start(new ProcessStartInfo(local) { UseShellExecute = true });
+        });
+    }
+
+    private async Task NavigateAsync(string path)
+    {
+        await navigationLock.WaitAsync();
+        try
+        {
+            IsLoading = true;
+            StatusMessage = null;
+
+            var entries = await connection.RunAsync(sftp => sftp
+                .ListDirectory(path)
+                .Where(entry => entry.Name is not "." and not "..")
+                .Select(entry => new RemoteFileItem
+                {
+                    Name = entry.Name,
+                    FullPath = entry.FullName,
+                    IsDirectory = entry.IsDirectory,
+                    Size = entry.IsDirectory ? 0 : entry.Length,
+                    LastModified = entry.LastWriteTime
+                })
+                .OrderByDescending(entry => entry.IsDirectory)
+                .ThenBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList());
+
+            currentPath = path;
+            Items.Clear();
+            foreach (var entry in entries)
+            {
+                Items.Add(entry);
+            }
+
+            PathSegments = BuildBreadcrumb();
+            if (Items.Count == 0)
+            {
+                StatusMessage = "FilesEmptyFolder".GetLocalizedResource();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to list {path}: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsLoading = false;
+            OnPropertyChanged(nameof(CanGoUp));
+            navigationLock.Release();
+        }
+    }
+
+    private IReadOnlyList<string> BuildBreadcrumb()
+    {
+        List<string> segments = [Volumes.Count > 0 ? Volumes[Math.Clamp(SelectedVolumeIndex, 0, Volumes.Count - 1)] : "/"];
+
+        var relative = currentPath.Length > rootPath.Length ? currentPath[rootPath.Length..] : string.Empty;
+        segments.AddRange(relative.Split('/', StringSplitOptions.RemoveEmptyEntries));
+        return segments;
+    }
+
+    #endregion
+
+    #region File operations
+
+    [RelayCommand]
+    private async Task Download(RemoteFileItem? item)
+    {
+        if (item is null || item.IsDirectory) return;
+
+        var folder = await PickerHelper.PickFolderAsync();
+        if (folder is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = Path.Combine(folder.Path, item.Name);
+            await connection.RunAsync(sftp =>
+            {
+                using var stream = File.Create(local);
+                sftp.DownloadFile(item.FullPath, stream);
+                return true;
+            });
+        });
+    }
+
+    [RelayCommand]
+    private async Task Upload()
+    {
+        var file = await PickerHelper.PickFileAsync();
+        if (file is null) return;
+
+        await RunAsync(async () =>
+        {
+            var target = CombinePath(currentPath, file.Name);
+            await connection.RunAsync(sftp =>
+            {
+                using var stream = File.OpenRead(file.Path);
+                sftp.UploadFile(stream, target);
+                return true;
+            });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    [RelayCommand]
+    private async Task NewFolder()
+    {
+        var name = await PromptForNameAsync(
+            "FilesNewFolder".GetLocalizedResource(),
+            "FilesCreate".GetLocalizedResource(),
+            string.Empty);
+        if (name is null) return;
+
+        await RunAsync(async () =>
+        {
+            var target = CombinePath(currentPath, name);
+            await connection.RunAsync(sftp => { sftp.CreateDirectory(target); return true; });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    [RelayCommand]
+    private async Task Rename(RemoteFileItem? item)
+    {
+        if (item is null) return;
+
+        var name = await PromptForNameAsync(
+            "FilesRename".GetLocalizedResource(),
+            "FilesRename".GetLocalizedResource(),
+            item.Name);
+        if (name is null || name == item.Name) return;
+
+        await RunAsync(async () =>
+        {
+            var target = CombinePath(currentPath, name);
+            await connection.RunAsync(sftp => { sftp.RenameFile(item.FullPath, target); return true; });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    [RelayCommand]
+    private async Task Delete(RemoteFileItem? item)
+    {
+        if (item is null) return;
+
+        var dialog = new ContentDialog
+        {
+            Title = "FilesDeleteTitle".GetLocalizedResource(),
+            Content = string.Format("FilesDeleteSubtitle".GetLocalizedResource(), item.Name),
+            PrimaryButtonText = "Remove".GetLocalizedResource(),
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        if (await dialog.ShowAsync() is not ContentDialogResult.Primary) return;
+
+        await RunAsync(async () =>
+        {
+            await connection.RunAsync(sftp =>
+            {
+                if (item.IsDirectory)
+                {
+                    DeleteRecursive(sftp, item.FullPath);
+                }
+                else
+                {
+                    sftp.DeleteFile(item.FullPath);
+                }
+                return true;
+            });
+            await NavigateAsync(currentPath);
+        });
+    }
+
+    private static void DeleteRecursive(SftpClient sftp, string path)
+    {
+        foreach (var entry in sftp.ListDirectory(path))
+        {
+            if (entry.Name is "." or "..") continue;
+
+            if (entry.IsDirectory)
+            {
+                DeleteRecursive(sftp, entry.FullName);
+            }
+            else
+            {
+                sftp.DeleteFile(entry.FullName);
+            }
+        }
+        sftp.DeleteDirectory(path);
+    }
+
+    #endregion
+
+    #region Plumbing
+
+    private static string Describe(Exception ex) => ex switch
+    {
+        InvalidOperationException => "FilesUnavailable".GetLocalizedResource(),
+        _ when DeviceSftpConnection.IsUnreachable(ex) => "FilesDisconnected".GetLocalizedResource(),
+        _ => ex.Message
+    };
+
+    private static string CombinePath(string directory, string name)
+        => directory.TrimEnd('/') + "/" + name;
+
+    /// <summary>
+    /// Runs an operation with the busy indicator on, turning any failure into a message instead of a crash.
+    /// </summary>
+    private async Task RunAsync(Func<Task> operation)
+    {
+        if (IsBusy) return;
+
+        IsBusy = true;
+        try
+        {
+            await operation();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"File operation failed: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static async Task<string?> PromptForNameAsync(string title, string primaryText, string initial)
+    {
+        var input = new TextBox
+        {
+            Text = initial,
+            SelectionStart = 0,
+            SelectionLength = initial.Length
+        };
+
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = input,
+            PrimaryButtonText = primaryText,
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        return await dialog.ShowAsync() is ContentDialogResult.Primary && !string.IsNullOrWhiteSpace(input.Text)
+            ? input.Text.Trim()
+            : null;
+    }
+
+    #endregion
+}

--- a/src/Sefirah/ViewModels/PhotosViewModel.cs
+++ b/src/Sefirah/ViewModels/PhotosViewModel.cs
@@ -1,0 +1,442 @@
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Security.Cryptography;
+using System.Text;
+using CommunityToolkit.WinUI;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Renci.SshNet;
+using Sefirah.Data.Models;
+using Sefirah.Utils;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
+
+namespace Sefirah.ViewModels;
+
+/// <summary>
+/// A gallery of the images on the device, with the actions that make a phone gallery useful from a
+/// desktop: copy one into the clipboard, keep it, or throw it away.
+/// </summary>
+public sealed partial class PhotosViewModel : BaseViewModel
+{
+    #region Services
+    private readonly IDeviceManager DeviceManager = Ioc.Default.GetRequiredService<IDeviceManager>();
+    private readonly ISftpFeature SftpFeature = Ioc.Default.GetRequiredService<ISftpFeature>();
+    private readonly ISessionManager SessionManager = Ioc.Default.GetRequiredService<ISessionManager>();
+    #endregion
+
+    /// <summary>Where phones keep pictures. Anything else is a file, not a photo.</summary>
+    private static readonly string[] PhotoFolders = ["DCIM", "Pictures", "Download"];
+
+    private static readonly string[] PhotoExtensions =
+        [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".heic"];
+
+    private const int MaxPhotos = 60;
+    private const int MaxDepth = 2;
+    private const int HeadBytes = 256 * 1024;
+
+    /// <summary>Above this, a preview is not worth pulling the whole image across the network.</summary>
+    private const long PreviewSizeLimit = 8L * 1024 * 1024;
+
+    private readonly DeviceSftpConnection connection = new();
+    private readonly SemaphoreSlim loadLock = new(1, 1);
+
+    private CancellationTokenSource? previewCts;
+    private bool listening;
+    private string? boundDeviceId;
+
+    public ObservableCollection<RemotePhotoItem> Photos { get; } = [];
+
+    [ObservableProperty]
+    public partial bool IsLoading { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsBusy { get; set; }
+
+    [ObservableProperty]
+    public partial string? StatusMessage { get; set; }
+
+    [ObservableProperty]
+    public partial RemotePhotoItem? SelectedPhoto { get; set; }
+
+    public bool HasStatus => !string.IsNullOrEmpty(StatusMessage);
+
+    partial void OnStatusMessageChanged(string? value) => OnPropertyChanged(nameof(HasStatus));
+
+    #region Lifetime
+
+    public async Task InitializeAsync()
+    {
+        if (!listening)
+        {
+            SftpFeature.SessionChanged += OnSessionChanged;
+            SessionManager.ConnectionStatusChanged += OnConnectionStatusChanged;
+            listening = true;
+        }
+
+        await LoadAsync();
+    }
+
+    public void Suspend()
+    {
+        if (listening)
+        {
+            SftpFeature.SessionChanged -= OnSessionChanged;
+            SessionManager.ConnectionStatusChanged -= OnConnectionStatusChanged;
+            listening = false;
+        }
+
+        previewCts?.Cancel();
+        connection.Drop();
+    }
+
+    private void OnSessionChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+
+        connection.Drop();
+        dispatcher.TryEnqueue(async () => await LoadAsync());
+    }
+
+    private void OnConnectionStatusChanged(object? sender, PairedDevice device)
+    {
+        if (boundDeviceId is not null && device.Id != boundDeviceId) return;
+        if (device.IsConnected) return;
+
+        previewCts?.Cancel();
+        connection.Drop();
+        dispatcher.TryEnqueue(() =>
+        {
+            Photos.Clear();
+            StatusMessage = "PhotosDisconnected".GetLocalizedResource();
+        });
+    }
+
+    #endregion
+
+    #region Loading
+
+    [RelayCommand]
+    private Task Refresh() => LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        if (!await loadLock.WaitAsync(0)) return;
+
+        previewCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        previewCts = cts;
+
+        try
+        {
+            boundDeviceId = DeviceManager.ActiveDevice?.Id;
+            IsLoading = true;
+            StatusMessage = null;
+
+            var session = connection.CurrentSession();
+            if (session is null)
+            {
+                Photos.Clear();
+                StatusMessage = "PhotosUnavailable".GetLocalizedResource();
+                return;
+            }
+
+            var root = (session.Paths.Count > 0 ? session.Paths[0] : "/").TrimEnd('/');
+            var found = await connection.RunAsync(sftp =>
+            {
+                List<RemotePhotoItem> photos = [];
+                foreach (var folder in PhotoFolders)
+                {
+                    Collect(sftp, $"{root}/{folder}", 0, photos);
+                }
+                return photos
+                    .OrderByDescending(photo => photo.LastModified)
+                    .Take(MaxPhotos)
+                    .ToList();
+            });
+
+            Photos.Clear();
+            foreach (var photo in found)
+            {
+                Photos.Add(photo);
+            }
+
+            if (Photos.Count == 0)
+            {
+                StatusMessage = "PhotosEmpty".GetLocalizedResource();
+                return;
+            }
+
+            // Previews trickle in afterwards so the grid appears immediately
+            _ = LoadPreviewsAsync([.. found], cts.Token);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Failed to list photos: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsLoading = false;
+            loadLock.Release();
+        }
+    }
+
+    private static void Collect(SftpClient sftp, string directory, int depth, List<RemotePhotoItem> into)
+    {
+        if (depth > MaxDepth) return;
+
+        try
+        {
+            foreach (var entry in sftp.ListDirectory(directory))
+            {
+                // Leading dots are thumbnails caches and trash, not the user's pictures
+                if (entry.Name is "." or ".." || entry.Name.StartsWith('.')) continue;
+
+                if (entry.IsDirectory)
+                {
+                    Collect(sftp, entry.FullName, depth + 1, into);
+                }
+                else if (PhotoExtensions.Contains(Path.GetExtension(entry.Name).ToLowerInvariant()))
+                {
+                    into.Add(new RemotePhotoItem
+                    {
+                        Name = entry.Name,
+                        FullPath = entry.FullName,
+                        Size = entry.Length,
+                        LastModified = entry.LastWriteTime
+                    });
+                }
+            }
+        }
+        catch
+        {
+            // A folder we cannot read is not worth failing the whole gallery over
+        }
+    }
+
+    private async Task LoadPreviewsAsync(IReadOnlyList<RemotePhotoItem> photos, CancellationToken token)
+    {
+        foreach (var photo in photos)
+        {
+            if (token.IsCancellationRequested) return;
+
+            try
+            {
+                var bytes = await FetchPreviewBytesAsync(photo, token);
+                if (bytes is null || token.IsCancellationRequested) continue;
+
+                await dispatcher.EnqueueAsync(async () =>
+                {
+                    var bitmap = new BitmapImage { DecodePixelWidth = 320 };
+                    using var stream = new InMemoryRandomAccessStream();
+                    await stream.WriteAsync(bytes.AsBuffer());
+                    stream.Seek(0);
+                    await bitmap.SetSourceAsync(stream);
+                    photo.Preview = bitmap;
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn($"No preview for {photo.Name}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads the head of the image first: that is often the whole file, and for camera shots it
+    /// carries an embedded preview, which saves pulling megabytes for a thumbnail.
+    /// </summary>
+    private async Task<byte[]?> FetchPreviewBytesAsync(RemotePhotoItem photo, CancellationToken token)
+    {
+        var cached = CachePathFor(photo);
+
+        // Only trust a cached copy that is the whole picture; a partial one would render as a torn image
+        if (File.Exists(cached) && new FileInfo(cached).Length == photo.Size)
+        {
+            photo.LocalPath = cached;
+            return await File.ReadAllBytesAsync(cached, token);
+        }
+
+        return await connection.RunAsync<byte[]?>(sftp =>
+        {
+            // Small enough that reading the head means reading the whole picture
+            if (photo.Size <= HeadBytes)
+            {
+                var whole = new byte[photo.Size];
+                using (var stream = sftp.OpenRead(photo.FullPath))
+                {
+                    stream.ReadExactly(whole);
+                }
+
+                Cache(cached, whole);
+                photo.LocalPath = cached;
+                return whole;
+            }
+
+            var head = new byte[HeadBytes];
+            using (var stream = sftp.OpenRead(photo.FullPath))
+            {
+                // ReadExactly, because a single Read over the network returns whatever has arrived so far
+                stream.ReadExactly(head);
+            }
+
+            if (ExifThumbnail.TryExtract(head) is { } embedded) return embedded;
+
+            if (photo.Size > PreviewSizeLimit) return null;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(cached)!);
+            using (var file = File.Create(cached))
+            {
+                sftp.DownloadFile(photo.FullPath, file);
+            }
+
+            photo.LocalPath = cached;
+            return File.ReadAllBytes(cached);
+        });
+    }
+
+    private static void Cache(string path, byte[] bytes)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, bytes);
+    }
+
+    #endregion
+
+    #region Actions
+
+    [RelayCommand]
+    private async Task Open(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = await EnsureLocalCopyAsync(photo);
+            Process.Start(new ProcessStartInfo(local) { UseShellExecute = true });
+        });
+    }
+
+    [RelayCommand]
+    private async Task Copy(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = await EnsureLocalCopyAsync(photo);
+            var file = await StorageFile.GetFileFromPathAsync(local);
+
+            // Both forms: as a bitmap for editors, as a file for Explorer and chat apps
+            var package = new DataPackage { RequestedOperation = DataPackageOperation.Copy };
+            package.Properties.PackageFamilyName = Package.Current.Id.FamilyName;
+            package.SetBitmap(RandomAccessStreamReference.CreateFromFile(file));
+            package.SetStorageItems([file], false);
+            Clipboard.SetContent(package);
+
+            StatusMessage = null;
+        });
+    }
+
+    [RelayCommand]
+    private async Task Save(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        var folder = await PickerHelper.PickFolderAsync();
+        if (folder is null) return;
+
+        await RunAsync(async () =>
+        {
+            var local = await EnsureLocalCopyAsync(photo);
+            File.Copy(local, Path.Combine(folder.Path, photo.Name), overwrite: true);
+        });
+    }
+
+    [RelayCommand]
+    private async Task Delete(RemotePhotoItem? photo)
+    {
+        if (photo is null) return;
+
+        var dialog = new ContentDialog
+        {
+            Title = "PhotosDeleteTitle".GetLocalizedResource(),
+            Content = string.Format("PhotosDeleteSubtitle".GetLocalizedResource(), photo.Name),
+            PrimaryButtonText = "Remove".GetLocalizedResource(),
+            CloseButtonText = "Cancel".GetLocalizedResource(),
+            DefaultButton = ContentDialogButton.Close,
+            XamlRoot = App.MainWindow.Content!.XamlRoot
+        };
+
+        if (await dialog.ShowAsync() is not ContentDialogResult.Primary) return;
+
+        await RunAsync(async () =>
+        {
+            await connection.RunAsync(sftp => { sftp.DeleteFile(photo.FullPath); return true; });
+            Photos.Remove(photo);
+
+            if (Photos.Count == 0)
+            {
+                StatusMessage = "PhotosEmpty".GetLocalizedResource();
+            }
+        });
+    }
+
+    private async Task<string> EnsureLocalCopyAsync(RemotePhotoItem photo)
+    {
+        var cached = CachePathFor(photo);
+        if (photo.LocalPath is { } existing && File.Exists(existing) && new FileInfo(existing).Length == photo.Size)
+        {
+            return existing;
+        }
+
+        await connection.RunAsync(sftp =>
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(cached)!);
+            using var file = File.Create(cached);
+            sftp.DownloadFile(photo.FullPath, file);
+            return true;
+        });
+
+        photo.LocalPath = cached;
+        return cached;
+    }
+
+    /// <summary>
+    /// Keyed on the full remote path so two pictures with the same name never collide.
+    /// </summary>
+    private static string CachePathFor(RemotePhotoItem photo)
+    {
+        var digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(photo.FullPath)))[..12];
+        return Path.Combine(Path.GetTempPath(), "Sefirah", "photos", $"{digest}_{photo.Name}");
+    }
+
+    private async Task RunAsync(Func<Task> operation)
+    {
+        if (IsBusy) return;
+
+        IsBusy = true;
+        try
+        {
+            await operation();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"Photo action failed: {ex.Message}", ex);
+            StatusMessage = Describe(ex);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private static string Describe(Exception ex) => ex switch
+    {
+        InvalidOperationException => "PhotosUnavailable".GetLocalizedResource(),
+        _ when DeviceSftpConnection.IsUnreachable(ex) => "PhotosDisconnected".GetLocalizedResource(),
+        _ => ex.Message
+    };
+
+    #endregion
+}

--- a/src/Sefirah/ViewModels/Settings/DevicesViewModel.cs
+++ b/src/Sefirah/ViewModels/Settings/DevicesViewModel.cs
@@ -16,6 +16,7 @@ public partial class DevicesViewModel : ObservableObject
     private SmsRepository SmsRepository { get; } = Ioc.Default.GetRequiredService<SmsRepository>();
     private CallLogRepository CallLogRepository { get; } = Ioc.Default.GetRequiredService<CallLogRepository>();
     private NotificationRepository NotificationRepository { get; } = Ioc.Default.GetRequiredService<NotificationRepository>();
+    private ClipboardRepository ClipboardRepository { get; } = Ioc.Default.GetRequiredService<ClipboardRepository>();
     #endregion
     
     public ObservableCollection<PairedDevice> PairedDevices => DeviceManager.PairedDevices;
@@ -91,6 +92,7 @@ public partial class DevicesViewModel : ObservableObject
                 ContactRepository.DeleteAllContactsForDevice(deviceId);
                 CallLogRepository.DeleteAllCallLogsForDevice(deviceId);
                 NotificationRepository.RemoveNotificationsForDevice(deviceId);
+                ClipboardRepository.DeleteAllForDevice(deviceId);
             });
         }
         catch (Exception ex)

--- a/src/Sefirah/Views/ClipboardPage.xaml
+++ b/src/Sefirah/Views/ClipboardPage.xaml
@@ -1,0 +1,172 @@
+﻿<Page
+    x:Class="Sefirah.Views.ClipboardPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Sefirah.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Sefirah.Helpers"
+    xmlns:local="using:Sefirah.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Sefirah.Data.Models"
+    xmlns:vm="using:Sefirah.ViewModels"
+    x:Name="ClipboardPageRoot"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:BooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" Inverse="True" />
+
+        <DataTemplate x:Key="ClipboardEntryTemplate" x:DataType="models:ClipboardEntry">
+            <Grid
+                Padding="12"
+                Background="Transparent"
+                ColumnSpacing="12"
+                IsRightTapEnabled="True">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Grid.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem
+                            Click="CopyEntryClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=ClipboardCopy}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8C8;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="DeleteEntryClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=Remove}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74D;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </Grid.ContextFlyout>
+
+                <!--  Image entries show the picture, text entries an icon  -->
+                <Border
+                    Grid.Column="0"
+                    Width="64"
+                    Height="64"
+                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                    CornerRadius="4">
+                    <Grid>
+                        <FontIcon
+                            FontSize="20"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Glyph="&#xE8C8;"
+                            Visibility="{x:Bind IsImage, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                        <Image
+                            Source="{x:Bind Thumbnail}"
+                            Stretch="UniformToFill"
+                            Visibility="{x:Bind IsImage, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    </Grid>
+                </Border>
+
+                <StackPanel
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Spacing="4">
+                    <TextBlock
+                        MaxLines="3"
+                        Text="{x:Bind Preview}"
+                        TextTrimming="CharacterEllipsis"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{x:Bind TimestampText}" />
+                </StackPanel>
+
+                <Button
+                    Grid.Column="2"
+                    VerticalAlignment="Center"
+                    Click="CopyEntryClick"
+                    DataContext="{x:Bind}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=ClipboardCopy}">
+                    <FontIcon FontSize="14" Glyph="&#xE8C8;" />
+                </Button>
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{helpers:ResourceString Name=ClipboardHistory}" />
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{helpers:ResourceString Name=ClipboardHistorySubtitle}"
+                    TextWrapping="Wrap" />
+            </StackPanel>
+
+            <StackPanel
+                Grid.Column="1"
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    Command="{x:Bind ViewModel.ClearCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=ClipboardClearTitle}">
+                    <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.RefreshCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesRefresh}">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="1">
+            <ListView
+                x:Name="EntriesListView"
+                IsItemClickEnabled="True"
+                ItemClick="EntriesListView_ItemClick"
+                ItemTemplate="{StaticResource ClipboardEntryTemplate}"
+                ItemsSource="{x:Bind ViewModel.Entries}"
+                SelectedItem="{x:Bind ViewModel.SelectedEntry, Mode=TwoWay}"
+                SelectionMode="Single">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+            </ListView>
+
+            <TextBlock
+                MaxWidth="420"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Visibility="{x:Bind ViewModel.HasStatus, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <ProgressRing
+                Width="32"
+                Height="32"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+        </Grid>
+    </Grid>
+</Page>

--- a/src/Sefirah/Views/ClipboardPage.xaml.cs
+++ b/src/Sefirah/Views/ClipboardPage.xaml.cs
@@ -1,0 +1,55 @@
+using Sefirah.Data.Models;
+using Sefirah.ViewModels;
+
+namespace Sefirah.Views;
+
+public sealed partial class ClipboardPage : Page
+{
+    public ClipboardViewModel ViewModel { get; }
+
+    public ClipboardPage()
+    {
+        InitializeComponent();
+        ViewModel = Ioc.Default.GetRequiredService<ClipboardViewModel>();
+
+        Loaded += ClipboardPage_Loaded;
+        Unloaded += ClipboardPage_Unloaded;
+    }
+
+    private async void ClipboardPage_Loaded(object sender, RoutedEventArgs e)
+        => await ViewModel.InitializeAsync();
+
+    private void ClipboardPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= ClipboardPage_Loaded;
+        Unloaded -= ClipboardPage_Unloaded;
+        ViewModel.Suspend();
+    }
+
+    private async void EntriesListView_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is ClipboardEntry entry)
+        {
+            await ViewModel.CopyCommand.ExecuteAsync(entry);
+        }
+    }
+
+    private async void CopyEntryClick(object sender, RoutedEventArgs e)
+    {
+        if (GetEntry(sender) is ClipboardEntry entry)
+        {
+            await ViewModel.CopyCommand.ExecuteAsync(entry);
+        }
+    }
+
+    private async void DeleteEntryClick(object sender, RoutedEventArgs e)
+    {
+        if (GetEntry(sender) is ClipboardEntry entry)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(entry);
+        }
+    }
+
+    private static ClipboardEntry? GetEntry(object sender)
+        => (sender as FrameworkElement)?.DataContext as ClipboardEntry;
+}

--- a/src/Sefirah/Views/FilesPage.xaml
+++ b/src/Sefirah/Views/FilesPage.xaml
@@ -1,0 +1,202 @@
+﻿<Page
+    x:Class="Sefirah.Views.FilesPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Sefirah.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Sefirah.Helpers"
+    xmlns:local="using:Sefirah.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Sefirah.Data.Models"
+    xmlns:vm="using:Sefirah.ViewModels"
+    x:Name="FilesPageRoot"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+        <DataTemplate x:Key="FileItemTemplate" x:DataType="models:RemoteFileItem">
+            <Grid
+                Padding="4,6"
+                ColumnSpacing="12"
+                Background="Transparent"
+                IsRightTapEnabled="True"
+                ToolTipService.ToolTip="{x:Bind Name}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Grid.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem
+                            Click="OpenItemClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=FilesOpen}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8E5;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="DownloadItemClick"
+                            DataContext="{x:Bind}"
+                            IsEnabled="{x:Bind IsFile}"
+                            Text="{helpers:ResourceString Name=FilesDownload}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE896;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem
+                            Click="RenameItemClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=FilesRename}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8AC;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="DeleteItemClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=Remove}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74D;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </Grid.ContextFlyout>
+
+                <FontIcon
+                    Grid.Column="0"
+                    FontSize="18"
+                    Glyph="{x:Bind Glyph}" />
+
+                <TextBlock
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Text="{x:Bind Name}"
+                    TextTrimming="CharacterEllipsis" />
+
+                <TextBlock
+                    Grid.Column="2"
+                    MinWidth="90"
+                    VerticalAlignment="Center"
+                    HorizontalTextAlignment="Right"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{x:Bind SizeText}" />
+
+                <TextBlock
+                    Grid.Column="3"
+                    MinWidth="130"
+                    VerticalAlignment="Center"
+                    HorizontalTextAlignment="Right"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{x:Bind LastModifiedText}" />
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!--  Path and actions  -->
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button
+                Grid.Column="0"
+                Command="{x:Bind ViewModel.GoUpCommand}"
+                IsEnabled="{x:Bind ViewModel.CanGoUp, Mode=OneWay}"
+                ToolTipService.ToolTip="{helpers:ResourceString Name=FilesGoUp}">
+                <FontIcon FontSize="14" Glyph="&#xE74A;" />
+            </Button>
+
+            <BreadcrumbBar
+                x:Name="PathBreadcrumbBar"
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                ItemsSource="{x:Bind ViewModel.PathSegments, Mode=OneWay}" />
+
+            <StackPanel
+                Grid.Column="2"
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    Command="{x:Bind ViewModel.NewFolderCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesNewFolder}">
+                    <FontIcon FontSize="14" Glyph="&#xE8F4;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.UploadCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesUpload}">
+                    <FontIcon FontSize="14" Glyph="&#xE898;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.RefreshCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesRefresh}">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <!--  Volume picker, only worth showing when the device exposes more than one  -->
+        <ComboBox
+            Grid.Row="1"
+            MinWidth="200"
+            ItemsSource="{x:Bind ViewModel.Volumes, Mode=OneWay}"
+            SelectedIndex="{x:Bind ViewModel.SelectedVolumeIndex, Mode=TwoWay}"
+            Visibility="{x:Bind ViewModel.HasMultipleVolumes, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+        <Grid Grid.Row="2">
+            <ListView
+                x:Name="FilesListView"
+                IsItemClickEnabled="True"
+                ItemClick="FilesListView_ItemClick"
+                ItemTemplate="{StaticResource FileItemTemplate}"
+                ItemsSource="{x:Bind ViewModel.Items}"
+                SelectionMode="Single">
+                <ListView.ItemContainerStyle>
+                    <Style TargetType="ListViewItem">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    </Style>
+                </ListView.ItemContainerStyle>
+            </ListView>
+
+            <TextBlock
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                MaxWidth="420"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Visibility="{x:Bind ViewModel.HasStatus, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <ProgressRing
+                Width="32"
+                Height="32"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+        </Grid>
+
+        <ProgressBar
+            Grid.Row="2"
+            VerticalAlignment="Top"
+            IsIndeterminate="True"
+            Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+    </Grid>
+</Page>

--- a/src/Sefirah/Views/FilesPage.xaml.cs
+++ b/src/Sefirah/Views/FilesPage.xaml.cs
@@ -1,0 +1,76 @@
+using Sefirah.Data.Models;
+using Sefirah.ViewModels;
+
+namespace Sefirah.Views;
+
+public sealed partial class FilesPage : Page
+{
+    public FilesViewModel ViewModel { get; }
+
+    public FilesPage()
+    {
+        InitializeComponent();
+        ViewModel = Ioc.Default.GetRequiredService<FilesViewModel>();
+
+        PathBreadcrumbBar.ItemClicked += PathBreadcrumbBar_ItemClicked;
+        Loaded += FilesPage_Loaded;
+        Unloaded += FilesPage_Unloaded;
+    }
+
+    private async void FilesPage_Loaded(object sender, RoutedEventArgs e)
+        => await ViewModel.InitializeAsync();
+
+    private void FilesPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        PathBreadcrumbBar.ItemClicked -= PathBreadcrumbBar_ItemClicked;
+        Loaded -= FilesPage_Loaded;
+        Unloaded -= FilesPage_Unloaded;
+        ViewModel.Suspend();
+    }
+
+    private async void PathBreadcrumbBar_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
+        => await ViewModel.NavigateToSegmentAsync(args.Index);
+
+    private async void FilesListView_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is RemoteFileItem item)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void OpenItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void DownloadItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.DownloadCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void RenameItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.RenameCommand.ExecuteAsync(item);
+        }
+    }
+
+    private async void DeleteItemClick(object sender, RoutedEventArgs e)
+    {
+        if (GetItem(sender) is RemoteFileItem item)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(item);
+        }
+    }
+
+    private static RemoteFileItem? GetItem(object sender)
+        => (sender as FrameworkElement)?.DataContext as RemoteFileItem;
+}

--- a/src/Sefirah/Views/MainPage.xaml
+++ b/src/Sefirah/Views/MainPage.xaml
@@ -219,6 +219,36 @@
                                 <FontIcon Glyph="&#xED35;" />
                             </NavigationViewItem.Icon>
                         </NavigationViewItem>
+
+                        <NavigationViewItem
+                            x:Name="FilesNavigationItem"
+                            Content="{helpers:ResourceString Name=Files}"
+                            Tag="Files"
+                            Visibility="{x:Bind ViewModel.Device, Converter={StaticResource EmptyObjectToVisibilityConverter}, Mode=OneWay}">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xE8B7;" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
+
+                        <NavigationViewItem
+                            x:Name="PhotosNavigationItem"
+                            Content="{helpers:ResourceString Name=Photos}"
+                            Tag="Photos"
+                            Visibility="{x:Bind ViewModel.Device, Converter={StaticResource EmptyObjectToVisibilityConverter}, Mode=OneWay}">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xEB9F;" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
+
+                        <NavigationViewItem
+                            x:Name="ClipboardNavigationItem"
+                            Content="{helpers:ResourceString Name=ClipboardHistory}"
+                            Tag="Clipboard"
+                            Visibility="{x:Bind ViewModel.Device, Converter={StaticResource EmptyObjectToVisibilityConverter}, Mode=OneWay}">
+                            <NavigationViewItem.Icon>
+                                <FontIcon Glyph="&#xE8C8;" />
+                            </NavigationViewItem.Icon>
+                        </NavigationViewItem>
                     </NavigationView.MenuItems>
 
                     <NavigationView.FooterMenuItems>

--- a/src/Sefirah/Views/MainPage.xaml.cs
+++ b/src/Sefirah/Views/MainPage.xaml.cs
@@ -16,7 +16,10 @@ public sealed partial class MainPage : Page
         { "Settings", typeof(SettingsPage) },
         { "Calls", typeof(CallsPage) },
         { "Messages", typeof(MessagesPage) },
-        { "Apps", typeof(AppsPage) }
+        { "Apps", typeof(AppsPage) },
+        { "Files", typeof(FilesPage) },
+        { "Photos", typeof(PhotosPage) },
+        { "Clipboard", typeof(ClipboardPage) }
     };
 
     public MainPage()
@@ -61,6 +64,9 @@ public sealed partial class MainPage : Page
             "Calls" => CallsNavigationItem,
             "Messages" => MessagesNavigationItem,
             "Apps" => AppsNavigationItem,
+            "Files" => FilesNavigationItem,
+            "Photos" => PhotosNavigationItem,
+            "Clipboard" => ClipboardNavigationItem,
             "Settings" => MainNavigationView.SettingsItem,
             _ => MainNavigationView.SelectedItem
         };

--- a/src/Sefirah/Views/PhotosPage.xaml
+++ b/src/Sefirah/Views/PhotosPage.xaml
@@ -1,0 +1,168 @@
+﻿<Page
+    x:Class="Sefirah.Views.PhotosPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="using:Sefirah.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="using:Sefirah.Helpers"
+    xmlns:local="using:Sefirah.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Sefirah.Data.Models"
+    xmlns:vm="using:Sefirah.ViewModels"
+    x:Name="PhotosPageRoot"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:EmptyObjectToVisibilityConverter x:Key="NoPreviewToVisibilityConverter" Inverse="True" />
+
+        <DataTemplate x:Key="PhotoTemplate" x:DataType="models:RemotePhotoItem">
+            <Grid
+                Width="170"
+                Height="170"
+                Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                CornerRadius="6"
+                IsRightTapEnabled="True"
+                ToolTipService.ToolTip="{x:Bind Tooltip}">
+
+                <Grid.ContextFlyout>
+                    <MenuFlyout>
+                        <MenuFlyoutItem
+                            Click="OpenPhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=PhotosOpen}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8E5;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="CopyPhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=PhotosCopy}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE8C8;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
+                            Click="SavePhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=PhotosSave}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74E;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutSeparator />
+                        <MenuFlyoutItem
+                            Click="DeletePhotoClick"
+                            DataContext="{x:Bind}"
+                            Text="{helpers:ResourceString Name=Remove}">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE74D;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </Grid.ContextFlyout>
+
+                <!--  Stands in until the preview arrives  -->
+                <FontIcon
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    FontSize="28"
+                    Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                    Glyph="&#xEB9F;"
+                    Visibility="{x:Bind Preview, Mode=OneWay, Converter={StaticResource NoPreviewToVisibilityConverter}}" />
+
+                <Image
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Source="{x:Bind Preview, Mode=OneWay}"
+                    Stretch="UniformToFill" />
+            </Grid>
+        </DataTemplate>
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!--  Actions on the selected picture  -->
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock
+                Grid.Column="0"
+                VerticalAlignment="Center"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="{helpers:ResourceString Name=PhotosRecent}" />
+
+            <StackPanel
+                Grid.Column="1"
+                Orientation="Horizontal"
+                Spacing="8">
+                <Button
+                    Command="{x:Bind ViewModel.CopyCommand}"
+                    CommandParameter="{x:Bind ViewModel.SelectedPhoto, Mode=OneWay}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=PhotosCopy}">
+                    <FontIcon FontSize="14" Glyph="&#xE8C8;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.SaveCommand}"
+                    CommandParameter="{x:Bind ViewModel.SelectedPhoto, Mode=OneWay}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=PhotosSave}">
+                    <FontIcon FontSize="14" Glyph="&#xE74E;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.DeleteCommand}"
+                    CommandParameter="{x:Bind ViewModel.SelectedPhoto, Mode=OneWay}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=Remove}">
+                    <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                </Button>
+                <Button
+                    Command="{x:Bind ViewModel.RefreshCommand}"
+                    ToolTipService.ToolTip="{helpers:ResourceString Name=FilesRefresh}">
+                    <FontIcon FontSize="14" Glyph="&#xE72C;" />
+                </Button>
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="1">
+            <GridView
+                x:Name="PhotosGridView"
+                IsItemClickEnabled="True"
+                ItemClick="PhotosGridView_ItemClick"
+                ItemTemplate="{StaticResource PhotoTemplate}"
+                ItemsSource="{x:Bind ViewModel.Photos}"
+                SelectedItem="{x:Bind ViewModel.SelectedPhoto, Mode=TwoWay}"
+                SelectionMode="Single" />
+
+            <TextBlock
+                MaxWidth="420"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Text="{x:Bind ViewModel.StatusMessage, Mode=OneWay}"
+                TextAlignment="Center"
+                TextWrapping="Wrap"
+                Visibility="{x:Bind ViewModel.HasStatus, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+            <ProgressRing
+                Width="32"
+                Height="32"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsActive="{x:Bind ViewModel.IsLoading, Mode=OneWay}" />
+        </Grid>
+
+        <ProgressBar
+            Grid.Row="1"
+            VerticalAlignment="Top"
+            IsIndeterminate="True"
+            Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+    </Grid>
+</Page>

--- a/src/Sefirah/Views/PhotosPage.xaml.cs
+++ b/src/Sefirah/Views/PhotosPage.xaml.cs
@@ -1,0 +1,71 @@
+using Sefirah.Data.Models;
+using Sefirah.ViewModels;
+
+namespace Sefirah.Views;
+
+public sealed partial class PhotosPage : Page
+{
+    public PhotosViewModel ViewModel { get; }
+
+    public PhotosPage()
+    {
+        InitializeComponent();
+        ViewModel = Ioc.Default.GetRequiredService<PhotosViewModel>();
+
+        Loaded += PhotosPage_Loaded;
+        Unloaded += PhotosPage_Unloaded;
+    }
+
+    private async void PhotosPage_Loaded(object sender, RoutedEventArgs e)
+        => await ViewModel.InitializeAsync();
+
+    private void PhotosPage_Unloaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= PhotosPage_Loaded;
+        Unloaded -= PhotosPage_Unloaded;
+        ViewModel.Suspend();
+    }
+
+    private async void PhotosGridView_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is RemotePhotoItem photo)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void OpenPhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.OpenCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void CopyPhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.CopyCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void SavePhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.SaveCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private async void DeletePhotoClick(object sender, RoutedEventArgs e)
+    {
+        if (GetPhoto(sender) is RemotePhotoItem photo)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(photo);
+        }
+    }
+
+    private static RemotePhotoItem? GetPhoto(object sender)
+        => (sender as FrameworkElement)?.DataContext as RemotePhotoItem;
+}

--- a/src/Sefirah/Views/Settings/DeviceDiscoveryPage.xaml
+++ b/src/Sefirah/Views/Settings/DeviceDiscoveryPage.xaml
@@ -79,6 +79,30 @@
                 </Button>
             </Grid>
 
+            <!--  Manual pairing, for networks where discovery cannot reach: VPN tunnels carry unicast but not broadcast  -->
+            <wuc:SettingsCard Header="{helpers:ResourceString Name=ConnectManually}">
+                <wuc:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE968;" />
+                </wuc:SettingsCard.HeaderIcon>
+                <wuc:SettingsCard.Description>
+                    <TextBlock x:Name="LocalAddressText" TextWrapping="Wrap" />
+                </wuc:SettingsCard.Description>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBox
+                        x:Name="ManualAddressBox"
+                        MinWidth="190"
+                        PlaceholderText="192.168.1.10" />
+                    <Button Click="ConnectByAddress_Click" Content="{helpers:ResourceString Name=Connect}" />
+                </StackPanel>
+            </wuc:SettingsCard>
+
+            <TextBlock
+                x:Name="ManualAddressStatus"
+                Margin="4,0,0,8"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                TextWrapping="Wrap" />
+
             <ItemsRepeater ItemsSource="{x:Bind ViewModel.DiscoveredDevices, Mode=OneWay}">
                 <ItemsRepeater.Layout>
                     <StackLayout Orientation="Vertical" Spacing="8" />

--- a/src/Sefirah/Views/Settings/DeviceDiscoveryPage.xaml.cs
+++ b/src/Sefirah/Views/Settings/DeviceDiscoveryPage.xaml.cs
@@ -15,6 +15,44 @@ public sealed partial class DeviceDiscoveryPage : Page
     {
         InitializeComponent();
         SetupBreadcrumb();
+        ShowLocalAddresses();
+    }
+
+    /// <summary>
+    /// Spelled out so the address can be typed on the other device when discovery cannot reach it.
+    /// </summary>
+    private void ShowLocalAddresses()
+    {
+        var addresses = NetworkHelper.GetAllValidAddresses().Select(a => a.Address.ToString()).ToList();
+        LocalAddressText.Text = addresses.Count > 0
+            ? string.Format("ThisDeviceAddress".GetLocalizedResource(), string.Join(", ", addresses))
+            : "ConnectManuallyDescription".GetLocalizedResource();
+    }
+
+    private void ConnectByAddress_Click(object sender, RoutedEventArgs e)
+    {
+        var input = ManualAddressBox.Text.Trim();
+        if (string.IsNullOrEmpty(input)) return;
+
+        var address = input;
+        var port = 5150;
+
+        var separator = input.LastIndexOf(':');
+        if (separator > 0 && int.TryParse(input[(separator + 1)..], out var parsedPort))
+        {
+            address = input[..separator];
+            port = parsedPort;
+        }
+
+        if (!System.Net.IPAddress.TryParse(address, out _))
+        {
+            ManualAddressStatus.Text = "InvalidAddress".GetLocalizedResource();
+            return;
+        }
+
+        // The id only guards against duplicate attempts; the device announces its real one at handshake
+        ManualAddressStatus.Text = string.Format("ConnectingToAddress".GetLocalizedResource(), address, port);
+        SessionManager.Connect(address, address, port);
     }
 
     private void SetupBreadcrumb()

--- a/src/Sefirah/appsettings.json
+++ b/src/Sefirah/appsettings.json
@@ -12,6 +12,7 @@
       "hi-IN",
       "hu-HU",
       "id-ID",
+      "it-IT",
       "ja-JP",
       "ko-KR",
       "nl-NL",


### PR DESCRIPTION
Two independent changes; happy to split them into separate PRs if you would rather take one without the other.

## Italian translation

`src/Sefirah/Strings/it-IT/Resources.resw`, complete against `Strings/en` at 322 strings, plus the `it-IT` entry in `LocalizationConfiguration`.

Technical tokens are deliberately untranslated: `GVfs`, `sshfs`, `Mica`, the `8M` / `128K` bitrate placeholders, the `ms` and `Mbps` units, and the `input keyevent` lines used as examples in the unlock help, since those are literal adb input. Every `{0}`/`{1}` slot and the `%pwd%` placeholder was checked against the source.

**On Crowdin:** `CONTRIBUTING.MD` points translators at Crowdin, and `crowdin.yml` writes into this same path, so tell me if this file would collide with your sync and I will drop it from the PR — the second commit stands on its own. Either way `it-IT` presumably needs enabling on the Crowdin side to keep receiving updates.

## Fix: system-language entry read the wrong culture

`AppLanguageHelper` took the code for the "use system setting" entry from `CultureInfo.InstalledUICulture`, which reports the language Windows was *installed* with, not the one the user picked. Inside a packaged app it answers `en-US` even on a machine running entirely in another language. `CurrentUICulture` is not a valid substitute either, since it follows the app's own `PrimaryLanguageOverride`. `GlobalizationPreferences.Languages` reports the display language and ignores the override.

The guard next to it was also dead code:

```csharp
if (appLanguages.Select(lang => lang.Name.Contains(systemLanguage.Name)).Any())
```

`Any()` without a predicate over a sequence of `bool` is true whenever the sequence is non-empty, so the `en-US` fallback was unreachable — and `systemLanguage.Name` is never a culture name, because the `systemDefault` constructor sets it to the localized "use system setting" string. Matching now happens on the code, accepting the neutral form too (`cs` covers `cs-CZ`), since manifest languages come back normalized.

This only changes the *code* of the first entry, not its label or its behaviour when selected — it still clears the override and leaves the choice to Windows. What it feeds is `IsPreferredLanguageRtl`.

## Checks

Both target frameworks build clean, `net10.0-windows10.0.26100` and `net10.0-desktop`. `GlobalizationPreferences.Languages` was verified to be implemented on the Uno side (it lives in `Uno.dll`, no `NotImplemented` attribute, returns the expected tag) so the desktop head does not regress. Verified at runtime inside the package that `ManifestLanguages` now contains `it-IT` and that `Languages` resolves to `it-IT` with an empty override.

One deployment note that cost some time: Windows caches `AppxManifest.xml` in the state repository at registration, so on an existing local deployment a newly added language keeps missing from `ApplicationLanguages.ManifestLanguages` until the package is registered again. The resw and `resources.pri` are correct well before the picker shows anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)